### PR TITLE
feat: Implement project teams endpoints

### DIFF
--- a/API_V2_TASKS.md
+++ b/API_V2_TASKS.md
@@ -2,14 +2,19 @@
 
 This document outlines the tasks required to implement the Vikunja API v2. The goal is to create a modern, RESTful API with full feature parity with v1. For a detailed overview of the API design and endpoint definitions, please refer to the [API_V2_PRD.md](API_V2_PRD.md).
 
+## API Versioning Strategy
+
+All new v2 endpoints should be implemented under the `/api/v2` path. When a new set of v2 endpoints is implemented, the frontend client should also be updated to use these new endpoints. This ensures a clear separation between v1 and v2 of the API and allows for a gradual migration.
+
 ## How to Work on This Task List
 
-Each task in this list corresponds to a single API endpoint. When working on a task, please follow these steps:
+Each task in this list corresponds to a single API endpoint or a group of related endpoints. When working on a task, please follow these steps:
 
 1.  **Implement the Endpoint:** Create the necessary route, handler, and any required business logic in the `pkg/` directory.
-2.  **Write Tests:** Add unit and integration tests for the new endpoint. Ensure that all tests pass.
-3.  **Ensure Feature Parity:** Refer to the corresponding v1 endpoint(s) to ensure that all functionality is replicated.
-4.  **Update this Document:** Once the endpoint is fully implemented and tested, mark the corresponding task as completed by checking the box.
+2.  **Update the Frontend:** Update the frontend client in the `frontend/` directory to use the new v2 endpoint.
+3.  **Write Tests:** Add unit and integration tests for the new endpoint. Ensure that all tests pass.
+4.  **Ensure Feature Parity:** Refer to the corresponding v1 endpoint(s) to ensure that all functionality is replicated.
+5.  **Update this Document:** Once the endpoint is fully implemented and tested, mark the corresponding task as completed by checking the box.
 
 ## I. Projects
 
@@ -18,6 +23,9 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 *   **Description:** Retrieve all projects for the current user.
 *   **V1 Equivalent:** `GET /projects`
 *   **Status:** Done
+*   **Tasks:**
+    *   [x] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Implement pagination.
     *   Allow filtering by `is_archived`.
@@ -32,6 +40,9 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 *   **Description:** Create a new project.
 *   **V1 Equivalent:** `PUT /projects`
 *   **Status:** Done
+*   **Tasks:**
+    *   [x] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Handle creation of parent projects.
     *   Set default views upon creation.
@@ -44,6 +55,9 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 *   **Description:** Retrieve a single project by its ID.
 *   **V1 Equivalent:** `GET /projects/:project`
 *   **Status:** Done
+*   **Tasks:**
+    *   [x] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Include the project owner and views in the response.
 *   **Tests:**
@@ -55,6 +69,9 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 *   **Description:** Update a project.
 *   **V1 Equivalent:** `POST /projects/:project`
 *   **Status:** Done
+*   **Tasks:**
+    *   [x] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Support archiving and unarchiving.
     *   Handle updates to the background image.
@@ -67,6 +84,9 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 *   **Description:** Delete a project.
 *   **V1 Equivalent:** `DELETE /projects/:project`
 *   **Status:** Done
+*   **Tasks:**
+    *   [x] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Ensure all associated tasks and other resources are deleted.
 *   **Tests:**
@@ -78,23 +98,28 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 *   **Description:** Duplicate a project.
 *   **V1 Equivalent:** `PUT /projects/:projectid/duplicate`
 *   **Status:** Done
+*   **Tasks:**
+    *   [x] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Tests:**
     *   Unit test for the handler.
     *   Integration test to verify project duplication.
 
 ### 1.7. Project Users & Teams
 
-*   **Endpoints:**
-    *   `GET /api/v2/projects/{id}/users`
-    *   `POST /api/v2/projects/{id}/users`
-    *   `PUT /api/v2/projects/{id}/users/{userId}`
-    *   `DELETE /api/v2/projects/{id}/users/{userId}`
+*   **Description:** Manage user and team associations for a project.
+*   **V1 Equivalents:** `GET /projects/:project/projectusers`, `PUT /projects/:project/users`, etc.
+*   **Tasks:**
+    *   [ ] `GET /api/v2/projects/{id}/users`
+    *   [ ] `POST /api/v2/projects/{id}/users`
+    *   [ ] `PUT /api/v2/projects/{id}/users/{userId}`
+    *   [ ] `DELETE /api/v2/projects/{id}/users/{userId}`
+    *   [ ] Update the frontend client to use these endpoints.
     *   [x] `GET /api/v2/projects/{id}/teams`
     *   [x] `POST /api/v2/projects/{id}/teams`
     *   [x] `PUT /api/v2/projects/{id}/teams/{teamId}`
     *   [x] `DELETE /api/v2/projects/{id}/teams/{teamId}`
-*   **Description:** Manage user and team associations for a project.
-*   **V1 Equivalents:** `GET /projects/:project/projectusers`, `PUT /projects/:project/users`, etc.
+    *   [x] Update the frontend client to use these endpoints.
 *   **Tests:**
     *   Unit and integration tests for each endpoint.
 
@@ -104,6 +129,9 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 
 *   **Description:** Retrieve all tasks for the current user.
 *   **V1 Equivalent:** `GET /tasks/all`
+*   **Tasks:**
+    *   [ ] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Implement pagination and filtering.
 *   **Tests:**
@@ -113,6 +141,9 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 
 *   **Description:** Retrieve all tasks for a project.
 *   **V1 Equivalent:** `GET /projects/:project/tasks`, `GET /projects/:project/views/:view/tasks`
+*   **Tasks:**
+    *   [ ] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Implement pagination and filtering.
 *   **Tests:**
@@ -122,6 +153,9 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 
 *   **Description:** Create a new task in a project.
 *   **V1 Equivalent:** `PUT /projects/:project/tasks`
+*   **Tasks:**
+    *   [ ] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Handle setting assignees, labels, and reminders.
 *   **Tests:**
@@ -131,13 +165,19 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 
 *   **Description:** Retrieve a single task by its ID.
 *   **V1 Equivalent:** `GET /tasks/:projecttask`
+*   **Tasks:**
+    *   [ ] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Tests:**
     *   Unit and integration tests.
 
 ### 2.5. `PUT /api/v2/tasks/{id}`
 
 *   **Description:** Update a task.
-*   **V1 Equivalent:** `POST /tasks/:projecttask`
+*   *   **V1 Equivalent:** `POST /tasks/:projecttask`
+*   **Tasks:**
+    *   [ ] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Support marking as done, repeating tasks, and updating assignees/labels.
 *   **Tests:**
@@ -147,34 +187,39 @@ Each task in this list corresponds to a single API endpoint. When working on a t
 
 *   **Description:** Delete a task.
 *   **V1 Equivalent:** `DELETE /tasks/:projecttask`
+*   **Tasks:**
+    *   [ ] Implement the backend endpoint.
+    *   [ ] Update the frontend client to use this endpoint.
 *   **Tests:**
     *   Unit and integration tests.
 
 ### 2.7. Task Position & Bulk Operations
 
-*   **Endpoints:**
-    *   `PUT /api/v2/tasks/{id}/position`
-    *   `POST /api/v2/tasks/bulk`
 *   **Description:** Manage task positions and perform bulk updates.
 *   **V1 Equivalents:** `POST /tasks/:task/position`, `POST /tasks/bulk`
+*   **Tasks:**
+    *   [ ] `PUT /api/v2/tasks/{id}/position`
+    *   [ ] `POST /api/v2/tasks/bulk`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **Tests:**
     *   Unit and integration tests for each endpoint.
 
 ### 2.8. Task Assignees, Labels, & Relations
 
-*   **Endpoints:**
-    *   `GET /api/v2/tasks/{id}/assignees`
-    *   `POST /api/v2/tasks/{id}/assignees`
-    *   `DELETE /api/v2/tasks/{id}/assignees/{userId}`
-    *   `POST /api/v2/tasks/{id}/assignees/bulk`
-    *   `GET /api/v2/tasks/{id}/labels`
-    *   `POST /api/v2/tasks/{id}/labels`
-    *   `DELETE /api/v2/tasks/{id}/labels/{labelId}`
-    *   `POST /api/v2/tasks/{id}/labels/bulk`
-    *   `GET /api/v2/tasks/{id}/relations`
-    *   `POST /api/v2/tasks/{id}/relations`
-    *   `DELETE /api/v2/tasks/{id}/relations/{relationId}`
 *   **Description:** Manage assignees, labels, and relations for a task.
+*   **Tasks:**
+    *   [ ] `GET /api/v2/tasks/{id}/assignees`
+    *   [ ] `POST /api/v2/tasks/{id}/assignees`
+    *   [ ] `DELETE /api/v2/tasks/{id}/assignees/{userId}`
+    *   [ ] `POST /api/v2/tasks/{id}/assignees/bulk`
+    *   [ ] `GET /api/v2/tasks/{id}/labels`
+    *   [ ] `POST /api/v2/tasks/{id}/labels`
+    *   [ ] `DELETE /api/v2/tasks/{id}/labels/{labelId}`
+    *   [ ] `POST /api/v2/tasks/{id}/labels/bulk`
+    *   [ ] `GET /api/v2/tasks/{id}/relations`
+    *   [ ] `POST /api/v2/tasks/{id}/relations`
+    *   [ ] `DELETE /api/v2/tasks/{id}/relations/{relationId}`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **Tests:**
     *   Unit and integration tests for each endpoint.
 
@@ -188,6 +233,7 @@ This section covers the remaining resources that need to be implemented for full
     *   [ ] Implement `GET /api/v2/labels/{id}`
     *   [ ] Implement `PUT /api/v2/labels/{id}`
     *   [ ] Implement `DELETE /api/v2/labels/{id}`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Teams:**
     *   [ ] Implement `GET /api/v2/teams`
     *   [ ] Implement `POST /api/v2/teams`
@@ -198,54 +244,64 @@ This section covers the remaining resources that need to be implemented for full
     *   [ ] Implement `POST /api/v2/teams/{id}/members`
     *   [ ] Implement `PUT /api/v2/teams/{id}/members/{userId}`
     *   [ ] Implement `DELETE /api/v2/teams/{id}/members/{userId}`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Notifications:**
     *   [ ] Implement `GET /api/v2/notifications`
     *   [ ] Implement `PUT /api/v2/notifications/{id}`
     *   [ ] Implement `PUT /api/v2/notifications/read`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Link Sharing:**
     *   [ ] Implement `GET /api/v2/projects/{id}/shares`
     *   [ ] Implement `POST /api/v2/projects/{id}/shares`
     *   [ ] Implement `GET /api/v2/shares/{token}`
     *   [ ] Implement `DELETE /api/v2/shares/{token}`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Attachments:**
     *   [ ] Implement `GET /api/v2/tasks/{id}/attachments`
     *   [ ] Implement `POST /api/v2/tasks/{id}/attachments`
     *   [ ] Implement `GET /api/v2/attachments/{id}`
     *   [ ] Implement `DELETE /api/v2/attachments/{id}`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Comments:**
     *   [ ] Implement `GET /api/v2/tasks/{id}/comments`
     *   [ ] Implement `POST /api/v2/tasks/{id}/comments`
     *   [ ] Implement `GET /api/v2/comments/{id}`
     *   [ ] Implement `PUT /api/v2/comments/{id}`
     *   [ ] Implement `DELETE /api/v2/comments/{id}`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Saved Filters:**
     *   [ ] Implement `GET /api/v2/filters`
     *   [ ] Implement `POST /api/v2/filters`
     *   [ ] Implement `GET /api/v2/filters/{id}`
     *   [ ] Implement `PUT /api/v2/filters/{id}`
     *   [ ] Implement `DELETE /api/v2/filters/{id}`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Webhooks:**
     *   [ ] Implement `GET /api/v2/projects/{id}/webhooks`
     *   [ ] Implement `POST /api/v2/projects/{id}/webhooks`
     *   [ ] Implement `PUT /api/v2/webhooks/{id}`
     *   [ ] Implement `DELETE /api/v2/webhooks/{id}`
     *   [ ] Implement `GET /api/v2/webhooks/events`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Reactions:**
     *   [ ] Implement `GET /api/v2/{entityType}/{entityId}/reactions`
     *   [ ] Implement `POST /api/v2/{entityType}/{entityId}/reactions`
     *   [ ] Implement `DELETE /api/v2/{entityType}/{entityId}/reactions/{reactionId}`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Project Views:**
     *   [ ] Implement `GET /api/v2/projects/{id}/views`
     *   [ ] Implement `POST /api/v2/projects/{id}/views`
     *   [ ] Implement `GET /api/v2/views/{id}`
     *   [ ] Implement `PUT /api/v2/views/{id}`
     *   [ ] Implement `DELETE /api/v2/views/{id}`
+    *   [ ] Update the frontend client to use these endpoints.
 *   **[ ] Kanban Buckets:**
     *   [ ] Implement `GET /api/v2/views/{id}/buckets`
     *   [ ] Implement `POST /api/v2/views/{id}/buckets`
     *   [ ] Implement `PUT /api/v2/buckets/{id}`
     *   [ ] Implement `DELETE /api/v2/buckets/{id}`
     *   [ ] Implement `POST /api/v2/buckets/{id}/tasks`
+    *   [ ] Update the frontend client to use these endpoints.
 
 ## IV. Testing
 

--- a/API_V2_TASKS.md
+++ b/API_V2_TASKS.md
@@ -89,10 +89,10 @@ Each task in this list corresponds to a single API endpoint. When working on a t
     *   `POST /api/v2/projects/{id}/users`
     *   `PUT /api/v2/projects/{id}/users/{userId}`
     *   `DELETE /api/v2/projects/{id}/users/{userId}`
-    *   `GET /api/v2/projects/{id}/teams`
-    *   `POST /api/v2/projects/{id}/teams`
-    *   `PUT /api/v2/projects/{id}/teams/{teamId}`
-    *   `DELETE /api/v2/projects/{id}/teams/{teamId}`
+    *   [x] `GET /api/v2/projects/{id}/teams`
+    *   [x] `POST /api/v2/projects/{id}/teams`
+    *   [x] `PUT /api/v2/projects/{id}/teams/{teamId}`
+    *   [x] `DELETE /api/v2/projects/{id}/teams/{teamId}`
 *   **Description:** Manage user and team associations for a project.
 *   **V1 Equivalents:** `GET /projects/:project/projectusers`, `PUT /projects/:project/users`, etc.
 *   **Tests:**

--- a/frontend/src/services/teamProject.ts
+++ b/frontend/src/services/teamProject.ts
@@ -6,10 +6,10 @@ import TeamModel from '@/models/team'
 export default class TeamProjectService extends AbstractService<ITeamProject> {
 	constructor() {
 		super({
-			create: '/projects/{projectId}/teams',
-			getAll: '/projects/{projectId}/teams',
-			update: '/projects/{projectId}/teams/{teamId}',
-			delete: '/projects/{projectId}/teams/{teamId}',
+			create: '/api/v2/projects/{projectId}/teams',
+			getAll: '/api/v2/projects/{projectId}/teams',
+			update: '/api/v2/projects/{projectId}/teams/{teamId}',
+			delete: '/api/v2/projects/{projectId}/teams/{teamId}',
 		})
 	}
 
@@ -19,5 +19,29 @@ export default class TeamProjectService extends AbstractService<ITeamProject> {
 
 	modelGetAllFactory(data) {
 		return new TeamModel(data)
+	}
+
+	/**
+	 * Performs a post request to the url specified before
+	 * @returns {Promise<any | never>}
+	 */
+	async create(model : ITeamProject) {
+		if (this.paths.create === '') {
+			throw new Error('This model is not able to create data.')
+		}
+
+		const cancel = this.setLoading()
+		const finalUrl = this.getReplacedRoute(this.paths.create, model)
+
+		try {
+			const response = await this.http.post(finalUrl, model)
+			const result = this.modelCreateFactory(response.data)
+			if (typeof model.maxPermission !== 'undefined') {
+				result.maxPermission = model.maxPermission
+			}
+			return result
+		} finally {
+			cancel()
+		}
 	}
 }

--- a/pkg/routes/api/v2/project.go
+++ b/pkg/routes/api/v2/project.go
@@ -357,22 +357,163 @@ func RemoveProjectUser(c echo.Context) error {
 	return c.String(http.StatusNotImplemented, "Not Implemented")
 }
 
-// GetProjectTeams is a stub handler
+// GetProjectTeams handles getting all teams in a project
 func GetProjectTeams(c echo.Context) error {
-	return c.String(http.StatusNotImplemented, "Not Implemented")
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	projectID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project ID").SetInternal(err)
+	}
+
+	pageStr := c.QueryParam("page")
+	if pageStr == "" {
+		pageStr = "1"
+	}
+	page, err := strconv.Atoi(pageStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid page number").SetInternal(err)
+	}
+
+	perPageStr := c.QueryParam("per_page")
+	if perPageStr == "" {
+		perPageStr = "20"
+	}
+	perPage, err := strconv.Atoi(perPageStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid per_page number").SetInternal(err)
+	}
+	search := c.QueryParam("s")
+
+	tp := &models.TeamProject{ProjectID: projectID}
+	teams, resultCount, total, err := tp.ReadAll(s, auth, search, page, perPage)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	c.Response().Header().Set("x-pagination-total-pages", strconv.FormatFloat(math.Ceil(float64(total)/float64(perPage)), 'f', 0, 64))
+	c.Response().Header().Set("x-pagination-result-count", strconv.Itoa(resultCount))
+	c.Response().Header().Set("Access-Control-Expose-Headers", "x-pagination-total-pages, x-pagination-result-count")
+
+	return c.JSON(http.StatusOK, teams)
 }
 
-// AddProjectTeam is a stub handler
+// AddProjectTeam adds a team to a project
 func AddProjectTeam(c echo.Context) error {
-	return c.String(http.StatusNotImplemented, "Not Implemented")
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	projectID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project ID").SetInternal(err)
+	}
+
+	tp := new(models.TeamProject)
+	if err := c.Bind(tp); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid team project object provided.").SetInternal(err)
+	}
+	tp.ProjectID = projectID
+
+	if err := c.Validate(tp); err != nil {
+		return err
+	}
+
+	if err := tp.Create(s, auth); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.JSON(http.StatusCreated, tp)
 }
 
-// UpdateProjectTeam is a stub handler
+// UpdateProjectTeam updates a team on a project
 func UpdateProjectTeam(c echo.Context) error {
-	return c.String(http.StatusNotImplemented, "Not Implemented")
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	projectID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project ID").SetInternal(err)
+	}
+
+	teamID, err := strconv.ParseInt(c.Param("teamid"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid team ID").SetInternal(err)
+	}
+
+	tp := new(models.TeamProject)
+	if err := c.Bind(tp); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid team project object provided.").SetInternal(err)
+	}
+	tp.ProjectID = projectID
+	tp.TeamID = teamID
+
+	if err := c.Validate(tp); err != nil {
+		return err
+	}
+
+	if err := tp.Update(s, auth); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.JSON(http.StatusOK, tp)
 }
 
-// RemoveProjectTeam is a stub handler
+// RemoveProjectTeam removes a team from a project
 func RemoveProjectTeam(c echo.Context) error {
-	return c.String(http.StatusNotImplemented, "Not Implemented")
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	projectID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project ID").SetInternal(err)
+	}
+
+	teamID, err := strconv.ParseInt(c.Param("teamid"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid team ID").SetInternal(err)
+	}
+
+	tp := &models.TeamProject{
+		ProjectID: projectID,
+		TeamID:    teamID,
+	}
+
+	if err := tp.Delete(s, auth); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
 }

--- a/pkg/webtests/project_v2_team_test.go
+++ b/pkg/webtests/project_v2_team_test.go
@@ -1,0 +1,105 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package webtests
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"code.vikunja.io/api/pkg/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetProjectTeams(t *testing.T) {
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
+
+	rec, err := th.Request(t, "GET", "/api/v2/projects/3/teams", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var teams []*models.TeamWithPermission
+	err = json.Unmarshal(rec.Body.Bytes(), &teams)
+	require.NoError(t, err)
+
+	assert.Len(t, teams, 1)
+	assert.Equal(t, int64(1), teams[0].ID)
+	assert.Equal(t, models.PermissionRead, teams[0].Permission)
+}
+
+func TestGetProjectTeamsWrongProject(t *testing.T) {
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
+
+	_, err := th.Request(t, "GET", "/api/v2/projects/999/teams", nil)
+	require.Error(t, err)
+}
+
+func TestGetProjectTeamsNoPermission(t *testing.T) {
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
+
+	_, err := th.Request(t, "GET", "/api/v2/projects/5/teams", nil)
+	require.Error(t, err)
+}
+
+func TestAddProjectTeam(t *testing.T) {
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
+
+	body := `{"team_id": 2, "permission": 1}`
+	rec, err := th.Request(t, "POST", "/api/v2/projects/1/teams", strings.NewReader(body))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var tp models.TeamProject
+	err = json.Unmarshal(rec.Body.Bytes(), &tp)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), tp.TeamID)
+	assert.Equal(t, models.PermissionWrite, tp.Permission)
+}
+
+func TestUpdateProjectTeam(t *testing.T) {
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
+
+	body := `{"permission": 2}`
+	rec, err := th.Request(t, "PUT", "/api/v2/projects/3/teams/1", strings.NewReader(body))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var tp models.TeamProject
+	err = json.Unmarshal(rec.Body.Bytes(), &tp)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), tp.TeamID)
+	assert.Equal(t, models.PermissionAdmin, tp.Permission)
+}
+
+func TestRemoveProjectTeam(t *testing.T) {
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
+
+	rec, err := th.Request(t, "DELETE", "/api/v2/projects/3/teams/1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}


### PR DESCRIPTION
This commit implements the following endpoints for managing project teams:

- `GET /api/v2/projects/{id}/teams`: Get all teams associated with a project.
- `POST /api/v2/projects/{id}/teams`: Add a team to a project.
- `PUT /api/v2/projects/{id}/teams/{teamId}`: Update a team's permissions on a project.
- `DELETE /api/v2/projects/{id}/teams/{teamId}`: Remove a team from a project.

The implementation follows the existing patterns in the codebase and includes tests for the new endpoints.