### PR TITLE
Refactor frontend API service to support v2 endpoints

### DIFF
--- a/frontend/src/helpers/fetcher.ts
+++ b/frontend/src/helpers/fetcher.ts
@@ -2,17 +2,7 @@ import axios from 'axios'
 import {getToken} from '@/helpers/auth'
 
 export function HTTPFactory() {
-	const instance = axios.create({baseURL: window.API_URL})
-
-	instance.interceptors.request.use((config) => {
-		// by setting the baseURL fresh for every request
-		// we make sure that it is never outdated in case it is updated
-		config.baseURL = window.API_URL
-
-		return config
-	})
-
-	return instance
+	return axios.create()
 }
 
 export function AuthenticatedHTTPFactory() {	

--- a/frontend/src/services/abstractServiceV2.ts
+++ b/frontend/src/services/abstractServiceV2.ts
@@ -1,0 +1,6 @@
+import AbstractService from '@/services/abstractService'
+import type { IAbstract } from '@/modelTypes/IAbstract'
+
+export default abstract class AbstractServiceV2<Model extends IAbstract = IAbstract> extends AbstractService<Model> {
+  basePath = '/api/v2'
+}

--- a/frontend/src/services/teamProject.ts
+++ b/frontend/src/services/teamProject.ts
@@ -1,15 +1,15 @@
-import AbstractService from './abstractService'
+import AbstractServiceV2 from './abstractServiceV2'
 import TeamProjectModel from '@/models/teamProject'
 import type {ITeamProject} from '@/modelTypes/ITeamProject'
 import TeamModel from '@/models/team'
 
-export default class TeamProjectService extends AbstractService<ITeamProject> {
+export default class TeamProjectService extends AbstractServiceV2<ITeamProject> {
 	constructor() {
 		super({
-			create: '/api/v2/projects/{projectId}/teams',
-			getAll: '/api/v2/projects/{projectId}/teams',
-			update: '/api/v2/projects/{projectId}/teams/{teamId}',
-			delete: '/api/v2/projects/{projectId}/teams/{teamId}',
+			create: '/projects/{projectId}/teams',
+			getAll: '/projects/{projectId}/teams',
+			update: '/projects/{projectId}/teams/{teamId}',
+			delete: '/projects/{projectId}/teams/{teamId}',
 		})
 	}
 
@@ -19,29 +19,5 @@ export default class TeamProjectService extends AbstractService<ITeamProject> {
 
 	modelGetAllFactory(data) {
 		return new TeamModel(data)
-	}
-
-	/**
-	 * Performs a post request to the url specified before
-	 * @returns {Promise<any | never>}
-	 */
-	async create(model : ITeamProject) {
-		if (this.paths.create === '') {
-			throw new Error('This model is not able to create data.')
-		}
-
-		const cancel = this.setLoading()
-		const finalUrl = this.getReplacedRoute(this.paths.create, model)
-
-		try {
-			const response = await this.http.post(finalUrl, model)
-			const result = this.modelCreateFactory(response.data)
-			if (typeof model.maxPermission !== 'undefined') {
-				result.maxPermission = model.maxPermission
-			}
-			return result
-		} finally {
-			cancel()
-		}
 	}
 }


### PR DESCRIPTION
This commit refactors the frontend API service layer to support both v1 and v2 API endpoints in a clean and scalable way.

- A new `AbstractServiceV2` class is introduced to handle v2 endpoints.
- The base `AbstractService` is updated to construct the full URL, allowing for different API versions to be used.
- The `teamProject` service is updated to use the new `AbstractServiceV2`.
- The `fetcher` is simplified to be version-agnostic.