### PR TITLE
feat: Implement POST /api/v2/projects/{id}/tasks endpoint

### DIFF
--- a/API_V2_TASKS.md
+++ b/API_V2_TASKS.md
@@ -148,7 +148,7 @@ Each task in this list corresponds to a single API endpoint or a group of relate
 *   **Description:** Create a new task in a project.
 *   **V1 Equivalent:** `PUT /projects/:project/tasks`
 *   **Tasks:**
-    *   [ ] Implement the backend endpoint.
+    *   [x] Implement the backend endpoint.
     *   [ ] Update the frontend client to use this endpoint.
 *   **Requirements:**
     *   Handle setting assignees, labels, and reminders.

--- a/pkg/routes/api/v2/project.go
+++ b/pkg/routes/api/v2/project.go
@@ -59,6 +59,7 @@ func RegisterProjects(a *echo.Group) {
 
 	// Project Tasks
 	projects.GET("/:id/tasks", GetProjectTasks)
+	projects.POST("/:id/tasks", CreateProjectTask)
 }
 
 type ProjectLinks struct {

--- a/pkg/routes/api/v2/project_tasks.go
+++ b/pkg/routes/api/v2/project_tasks.go
@@ -114,3 +114,61 @@ func GetProjectTasks(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, tasks)
 }
+
+// CreateProjectTask creates a new task in a project
+// @Summary Create a new task in a project
+// @Description Creates a new task in a project.
+// @tags project
+// @Accept  json
+// @Produce  json
+// @Param id path int64 true "The project id"
+// @Param task body models.Task true "The task to create"
+// @Success 201 {object} models.Task
+// @Failure 400 {object} web.HTTPError
+// @Failure 401 {object} web.HTTPError
+// @Failure 403 {object} web.HTTPError
+// @Failure 404 {object} web.HTTPError
+// @Router /projects/{id}/tasks [post]
+func CreateProjectTask(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	projectID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project ID").SetInternal(err)
+	}
+
+	p := &models.Project{ID: projectID}
+	can, err := p.CanWrite(s, auth)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+	if !can {
+		return echo.ErrForbidden
+	}
+
+	t := new(models.Task)
+	if err := c.Bind(t); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid task object provided.").SetInternal(err)
+	}
+	t.ProjectID = projectID
+
+	if err := c.Validate(t); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
+	}
+
+	if err := t.Create(s, auth); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.JSON(http.StatusCreated, t)
+}

--- a/pkg/routes/api/v2/project_tasks_test.go
+++ b/pkg/routes/api/v2/project_tasks_test.go
@@ -1,0 +1,65 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package v2
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/web"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateProjectTask(t *testing.T) {
+	e, auth := web.NewTestContext(t)
+
+	p := &models.Project{
+		OwnerID: auth.User.ID,
+		Title:   "Test Project",
+	}
+	err := p.Create(e.DB, auth)
+	assert.NoError(t, err)
+
+	task := &models.Task{
+		Title: "Test Task",
+	}
+	body, err := json.Marshal(task)
+	assert.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/projects/{id}/tasks", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(p.GetIDString())
+
+	err = CreateProjectTask(c)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var createdTask models.Task
+	err = json.Unmarshal(rec.Body.Bytes(), &createdTask)
+	assert.NoError(t, err)
+	assert.Equal(t, task.Title, createdTask.Title)
+	assert.Equal(t, p.ID, createdTask.ProjectID)
+}


### PR DESCRIPTION
This commit implements the `POST /api/v2/projects/{id}/tasks` endpoint to allow creating tasks within a project.

The implementation includes:
- A new route in `pkg/routes/api/v2/project.go`.
- A new handler function `CreateProjectTask` in `pkg/routes/api/v2/project_tasks.go`.
- A new test file `pkg/routes/api/v2/project_tasks_test.go` with a test for the new endpoint.
- An update to `API_V2_TASKS.md` to mark the task as complete.