### PR TITLE
WIP: Refactor Labels API to use Service Layer

### DIFF
--- a/pkg/models/label_test.go
+++ b/pkg/models/label_test.go
@@ -443,7 +443,7 @@ func TestLabel_Update(t *testing.T) {
 			if !allowed && !tt.wantForbidden {
 				t.Errorf("Label.CanUpdate() forbidden, want %v", tt.wantForbidden)
 			}
-			if err := l.Update(s, tt.auth); (err != nil) != tt.wantErr {
+			if err := l.Update(s); (err != nil) != tt.wantErr {
 				t.Errorf("Label.Update() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && !tt.wantForbidden {
@@ -529,7 +529,7 @@ func TestLabel_Delete(t *testing.T) {
 			if !allowed && !tt.wantForbidden {
 				t.Errorf("Label.CanDelete() forbidden, want %v", tt.wantForbidden)
 			}
-			if err := l.Delete(s, tt.auth); (err != nil) != tt.wantErr {
+			if err := l.Delete(s); (err != nil) != tt.wantErr {
 				t.Errorf("Label.Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && !tt.wantForbidden {

--- a/pkg/models/saved_filters_test.go
+++ b/pkg/models/saved_filters_test.go
@@ -182,7 +182,7 @@ func TestSavedFilter_Delete(t *testing.T) {
 	sf := &SavedFilter{
 		ID: 1,
 	}
-	err := sf.Delete(s, &user.User{ID: 1})
+	err := sf.Delete(s)
 	require.NoError(t, err)
 	err = s.Commit()
 	require.NoError(t, err)

--- a/pkg/models/task_comments_test.go
+++ b/pkg/models/task_comments_test.go
@@ -106,7 +106,7 @@ func TestTaskComment_Delete(t *testing.T) {
 			ID:     1,
 			TaskID: 1,
 		}
-		err := tc.Delete(s, u)
+		err := tc.Delete(s)
 		require.NoError(t, err)
 		err = s.Commit()
 		require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestTaskComment_Delete(t *testing.T) {
 		defer s.Close()
 
 		tc := &TaskComment{ID: 9999}
-		err := tc.Delete(s, u)
+		err := tc.Delete(s)
 		require.Error(t, err)
 		assert.True(t, IsErrTaskCommentDoesNotExist(err))
 	})
@@ -149,7 +149,7 @@ func TestTaskComment_Update(t *testing.T) {
 			ID:      1,
 			Comment: "testing",
 		}
-		err := tc.Update(s, u)
+		err := tc.Update(s)
 		require.NoError(t, err)
 		err = s.Commit()
 		require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestTaskComment_Update(t *testing.T) {
 		tc := &TaskComment{
 			ID: 9999,
 		}
-		err := tc.Update(s, u)
+		err := tc.Update(s)
 		require.Error(t, err)
 		assert.True(t, IsErrTaskCommentDoesNotExist(err))
 	})
@@ -192,7 +192,7 @@ func TestTaskComment_ReadOne(t *testing.T) {
 		defer s.Close()
 
 		tc := &TaskComment{ID: 1, TaskID: 1}
-		err := tc.ReadOne(s, u)
+		err := tc.ReadOne(s)
 		require.NoError(t, err)
 		assert.Equal(t, "Lorem Ipsum Dolor Sit Amet", tc.Comment)
 		assert.NotEmpty(t, tc.Author.ID)

--- a/pkg/routes/api/v1/labels.go
+++ b/pkg/routes/api/v1/labels.go
@@ -1,0 +1,206 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package v1
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+
+	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/modules/auth"
+	"code.vikunja.io/api/pkg/services"
+	"code.vikunja.io/api/pkg/web/handler"
+	"github.com/labstack/echo/v4"
+)
+
+func RegisterLabels(a *echo.Group) {
+	labels := a.Group("/labels")
+	labels.GET("", GetAllLabels)
+	labels.POST("", CreateLabel)
+	labels.GET("/:id", GetLabel)
+	labels.PUT("/:id", UpdateLabel)
+	labels.DELETE("/:id", DeleteLabel)
+}
+
+func GetAllLabels(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	pageStr := c.QueryParam("page")
+	if pageStr == "" {
+		pageStr = "1"
+	}
+	page, err := strconv.Atoi(pageStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid page number").SetInternal(err)
+	}
+
+	perPageStr := c.QueryParam("per_page")
+	if perPageStr == "" {
+		perPageStr = "20"
+	}
+	perPage, err := strconv.Atoi(perPageStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid per_page number").SetInternal(err)
+	}
+
+	search := c.QueryParam("s")
+
+	ls := services.NewLabelService()
+	labels, resultCount, total, err := ls.GetAll(s, auth, search, page, perPage)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	var numberOfPages = math.Ceil(float64(total) / float64(perPage))
+	if page < 0 {
+		numberOfPages = 1
+	}
+	if resultCount == 0 {
+		numberOfPages = 0
+	}
+
+	c.Response().Header().Set("x-pagination-total-pages", strconv.FormatFloat(numberOfPages, 'f', 0, 64))
+	c.Response().Header().Set("x-pagination-result-count", strconv.Itoa(resultCount))
+	c.Response().Header().Set("Access-Control-Expose-Headers", "x-pagination-total-pages, x-pagination-result-count")
+
+	return c.JSON(http.StatusOK, labels)
+}
+
+func CreateLabel(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	l := new(models.Label)
+	if err := c.Bind(l); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid label object provided.").SetInternal(err)
+	}
+
+	if err := c.Validate(l); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
+	}
+
+	ls := services.NewLabelService()
+	l, err = ls.Create(s, l, auth)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.JSON(http.StatusCreated, l)
+}
+
+func GetLabel(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	labelID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid label ID").SetInternal(err)
+	}
+
+	ls := services.NewLabelService()
+	l, err := ls.Get(s, labelID, auth)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.JSON(http.StatusOK, l)
+}
+
+func UpdateLabel(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	labelID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid label ID").SetInternal(err)
+	}
+
+	updatePayload := new(models.Label)
+	if err := c.Bind(updatePayload); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid label object provided.").SetInternal(err)
+	}
+	updatePayload.ID = labelID
+
+	if err := c.Validate(updatePayload); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
+	}
+
+	ls := services.NewLabelService()
+	l, err := ls.Update(s, updatePayload, auth)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.JSON(http.StatusOK, l)
+}
+
+func DeleteLabel(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	labelID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid label ID").SetInternal(err)
+	}
+
+	ls := services.NewLabelService()
+	if err := ls.Delete(s, labelID, auth); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -360,6 +360,7 @@ func registerAPIRoutes(a *echo.Group) {
 		u.POST("/deletion/confirm", apiv1.UserConfirmDeletion)
 		u.POST("/deletion/cancel", apiv1.UserCancelDeletion)
 	}
+	apiv1.RegisterLabels(a)
 	/*
 		projectHandler := &handler.WebHandler{
 			EmptyStruct: func() handler.CObject {
@@ -499,17 +500,6 @@ func registerAPIRoutes(a *echo.Group) {
 			a.POST("/tasks/:task/comments/:commentid", taskCommentHandler.UpdateWeb)
 			a.GET("/tasks/:task/comments/:commentid", taskCommentHandler.ReadOneWeb)
 		}
-
-		labelHandler := &handler.WebHandler{
-			EmptyStruct: func() handler.CObject {
-				return &models.Label{}
-			},
-		}
-		a.GET("/labels", labelHandler.ReadAllWeb)
-		a.GET("/labels/:label", labelHandler.ReadOneWeb)
-		a.PUT("/labels", labelHandler.CreateWeb)
-		a.DELETE("/labels/:label", labelHandler.DeleteWeb)
-		a.POST("/labels/:label", labelHandler.UpdateWeb)
 
 		projectTeamHandler := &handler.WebHandler{
 			EmptyStruct: func() handler.CObject {

--- a/pkg/services/label.go
+++ b/pkg/services/label.go
@@ -1,0 +1,112 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/user"
+	"code.vikunja.io/api/pkg/web"
+	"github.com/labstack/echo/v4"
+	"xorm.io/xorm"
+)
+
+// LabelService is a service for managing labels.
+type LabelService struct{}
+
+// NewLabelService returns a new LabelService.
+func NewLabelService() *LabelService {
+	return &LabelService{}
+}
+
+func (ls *LabelService) GetAll(s *xorm.Session, a web.Auth, search string, page int, perPage int) (result interface{}, resultCount int, totalItems int64, err error) {
+	u, err := user.GetFromAuth(a)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	return (&models.Label{}).ReadAll(s, u, search, page, perPage)
+}
+
+func (ls *LabelService) Get(s *xorm.Session, labelID int64, a web.Auth) (*models.Label, error) {
+	u, err := user.GetFromAuth(a)
+	if err != nil {
+		return nil, err
+	}
+
+	l := &models.Label{ID: labelID}
+	can, _, err := l.CanRead(s, u)
+	if err != nil {
+		return nil, err
+	}
+	if !can {
+		return nil, echo.ErrForbidden
+	}
+
+	if err := l.ReadOne(s); err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+func (ls *LabelService) Create(s *xorm.Session, l *models.Label, a web.Auth) (*models.Label, error) {
+	u, err := user.GetFromAuth(a)
+	if err != nil {
+		return nil, err
+	}
+	if err := l.Create(s, u); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func (ls *LabelService) Update(s *xorm.Session, l *models.Label, a web.Auth) (*models.Label, error) {
+	u, err := user.GetFromAuth(a)
+	if err != nil {
+		return nil, err
+	}
+
+	can, err := l.CanUpdate(s, u)
+	if err != nil {
+		return nil, err
+	}
+	if !can {
+		return nil, echo.ErrForbidden
+	}
+
+	if err := l.Update(s); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func (ls *LabelService) Delete(s *xorm.Session, labelID int64, a web.Auth) error {
+	u, err := user.GetFromAuth(a)
+	if err != nil {
+		return err
+	}
+
+	l := &models.Label{ID: labelID}
+	can, err := l.CanDelete(s, u)
+	if err != nil {
+		return err
+	}
+	if !can {
+		return echo.ErrForbidden
+	}
+
+	return l.Delete(s)
+}

--- a/pkg/webtests/label_test.go
+++ b/pkg/webtests/label_test.go
@@ -1,0 +1,82 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package webtests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getIDFromJSON(t *testing.T, body string) string {
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(body), &data)
+	require.NoError(t, err)
+	return fmt.Sprintf("%v", data["id"])
+}
+
+func TestLabelAPI(t *testing.T) {
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
+
+	// Create a label
+	payload := `{"title":"My Test Label","description":"A test label","hex_color":"ff00ff"}`
+	rec, err := th.Request(t, "POST", "/api/v1/labels", strings.NewReader(payload))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"title":"My Test Label"`)
+	assert.Contains(t, body, `"description":"A test label"`)
+	assert.Contains(t, body, `"hex_color":"ff00ff"`)
+
+	// Extract the id of the new label
+	id := getIDFromJSON(t, body)
+
+	// Get the label
+	rec, err = th.Request(t, "GET", "/api/v1/labels/"+id, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"title":"My Test Label"`)
+
+	// Get all labels
+	rec, err = th.Request(t, "GET", "/api/v1/labels", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, strings.Contains(rec.Body.String(), `"title":"My Test Label"`))
+
+	// Update the label
+	updatePayload := `{"title":"My Updated Label"}`
+	rec, err = th.Request(t, "PUT", "/api/v1/labels/"+id, strings.NewReader(updatePayload))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"title":"My Updated Label"`)
+
+	// Delete the label
+	rec, err = th.Request(t, "DELETE", "/api/v1/labels/"+id, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Verify the label is gone
+	rec, err = th.Request(t, "GET", "/api/v1/labels/"+id, nil)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}


### PR DESCRIPTION
This commit is part of a larger effort to refactor the API by introducing a service layer to resolve circular dependencies.

This change introduces a new service-based implementation for the v1 Labels API.

Key changes:
- A new `LabelService` is created in `pkg/services/label.go` to encapsulate business logic and permission checks for labels.
- New API handlers for labels are implemented in `pkg/routes/api/v1/labels.go`, following the patterns of the v2 API.
- The main router in `pkg/routes/routes.go` is updated to use the new label handlers, and the old generic handler for labels is removed.
- A new test file, `pkg/webtests/label_test.go`, is created to provide dedicated tests for the new Labels API endpoints.

Additionally, this commit includes fixes for compilation errors in the test files for the `models` package (`label_test.go`, `saved_filters_test.go`, `task_comments_test.go`). These fixes were necessary to unblock the test suite and allow for verification of the new implementation.

The work is still in progress, as the broader test suite is not yet passing due to other parts of the v1 API that still need to be refactored.