### PR TITLE
Refactor: Continue service layer refactoring

### DIFF
--- a/pkg/routes/api/v1/project.go
+++ b/pkg/routes/api/v1/project.go
@@ -1,0 +1,222 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package v1
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+
+	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/modules/auth"
+	"code.vikunja.io/api/pkg/services"
+	"code.vikunja.io/api/pkg/web/handler"
+	"github.com/labstack/echo/v4"
+)
+
+// RegisterProjects registers all project routes
+func RegisterProjects(a *echo.Group) {
+	a.GET("/projects", GetAllProjects)
+	a.GET("/projects/:project", GetProject)
+	a.POST("/projects/:project", UpdateProject)
+	a.DELETE("/projects/:project", DeleteProject)
+	a.PUT("/projects", CreateProject)
+}
+
+func GetAllProjects(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	pageStr := c.QueryParam("page")
+	if pageStr == "" {
+		pageStr = "1"
+	}
+	page, err := strconv.Atoi(pageStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid page number").SetInternal(err)
+	}
+
+	perPageStr := c.QueryParam("per_page")
+	if perPageStr == "" {
+		perPageStr = "20"
+	}
+	perPage, err := strconv.Atoi(perPageStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid per_page number").SetInternal(err)
+	}
+
+	search := c.QueryParam("s")
+	p := new(models.Project)
+	_ = c.Bind(p)
+
+	ps := services.NewProjectService()
+	projects, resultCount, total, err := ps.GetAll(s, auth, p, search, page, perPage)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if projects, ok := projects.([]*models.Project); ok {
+		for _, p := range projects {
+			services.AddProjectLinks(c, p)
+		}
+	}
+
+	var numberOfPages = math.Ceil(float64(total) / float64(perPage))
+	if page < 0 {
+		numberOfPages = 1
+	}
+	if resultCount == 0 {
+		numberOfPages = 0
+	}
+
+	c.Response().Header().Set("x-pagination-total-pages", strconv.FormatFloat(numberOfPages, 'f', 0, 64))
+	c.Response().Header().Set("x-pagination-result-count", strconv.Itoa(resultCount))
+	c.Response().Header().Set("Access-Control-Expose-Headers", "x-pagination-total-pages, x-pagination-result-count")
+
+	return c.JSON(http.StatusOK, projects)
+}
+
+func GetProject(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	projectID, err := strconv.ParseInt(c.Param("project"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project ID").SetInternal(err)
+	}
+
+	ps := services.NewProjectService()
+	p, err := ps.Get(s, projectID, auth)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	perm, err := ps.GetMaxPermission(s, p.ID, auth)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+	c.Response().Header().Set("x-max-permission", strconv.Itoa(int(perm)))
+
+	return c.JSON(http.StatusOK, p)
+}
+
+func UpdateProject(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	projectID, err := strconv.ParseInt(c.Param("project"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project ID").SetInternal(err)
+	}
+
+	updatePayload := new(models.Project)
+	if err := c.Bind(updatePayload); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project object provided.").SetInternal(err)
+	}
+
+	// Set the ID from the URL param, not the payload
+	updatePayload.ID = projectID
+
+	if err := c.Validate(updatePayload); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
+	}
+
+	ps := services.NewProjectService()
+	p, err := ps.Update(s, updatePayload, auth)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.JSON(http.StatusOK, p)
+}
+
+func DeleteProject(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	projectID, err := strconv.ParseInt(c.Param("project"), 10, 64)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project ID").SetInternal(err)
+	}
+
+	ps := services.NewProjectService()
+	if err := ps.Delete(s, projectID, auth); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+func CreateProject(c echo.Context) error {
+	s := db.NewSession()
+	defer s.Close()
+
+	auth, err := auth.GetAuthFromClaims(c)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	p := new(models.Project)
+	if err := c.Bind(p); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid project object provided.").SetInternal(err)
+	}
+
+	if err := c.Validate(p); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error()).SetInternal(err)
+	}
+
+	ps := services.NewProjectService()
+	p, err = ps.Create(s, p, auth)
+	if err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return handler.HandleHTTPError(err)
+	}
+
+	return c.JSON(http.StatusCreated, p)
+}

--- a/pkg/routes/api/v2/project_users.go
+++ b/pkg/routes/api/v2/project_users.go
@@ -79,7 +79,7 @@ func (pu *ProjectUsers) Get(c echo.Context) error {
 
 	if users, ok := users.([]*models.UserWithPermission); ok {
 		for _, u := range users {
-			u.User.Links = map[string]interface{}{"self": map[string]string{"href": "/api/v2/users/" + strconv.FormatInt(u.User.ID, 10), "method": "GET"}}
+			u.Links = models.Links{"self": {HREF: "/api/v2/users/" + strconv.FormatInt(u.User.ID, 10), Method: "GET"}}
 		}
 	}
 

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -241,7 +241,6 @@ func registerAPIRoutesV2(a *echo.Group) {
 }
 
 func registerAPIRoutes(a *echo.Group) {
-
 	// This is the group with no auth
 	// It is its own group to be able to rate limit this based on different heuristics
 	n := a.Group("")
@@ -318,6 +317,8 @@ func registerAPIRoutes(a *echo.Group) {
 
 	// Middleware to collect metrics
 	setupMetricsMiddleware(a)
+
+	apiv1.RegisterProjects(a)
 
 	a.GET("/token/test", apiv1.TestToken)
 	a.POST("/token/test", apiv1.CheckToken)

--- a/pkg/services/project.go
+++ b/pkg/services/project.go
@@ -135,6 +135,14 @@ func (ps *ProjectService) Delete(s *xorm.Session, projectID int64, a web.Auth) e
 	return p.Delete(s, u)
 }
 
+func (ps *ProjectService) GetMaxPermission(s *xorm.Session, projectID int64, a web.Auth) (models.Permission, error) {
+	u, err := user.GetFromAuth(a)
+	if err != nil {
+		return models.PermissionUnknown, err
+	}
+	return models.GetMaxPermissionForProject(s, u, projectID)
+}
+
 func AddProjectLinks(c echo.Context, p *models.Project) {
 	p.Links = models.Links{
 		"self": {

--- a/pkg/webtests/integrations.go
+++ b/pkg/webtests/integrations.go
@@ -303,6 +303,16 @@ func (th *testHelper) Login(t *testing.T, user *user.User) {
 	th.token = loginResponse["token"]
 }
 
+func (th *testHelper) Logout(t *testing.T) {
+	th.token = ""
+}
+
+func (th *testHelper) SetLinkShare(t *testing.T, ls *models.LinkSharing) {
+	token, err := auth.NewLinkShareJWTAuthtoken(ls)
+	require.NoError(t, err)
+	th.token = token
+}
+
 func (th *testHelper) Request(t *testing.T, method, path string, payload io.Reader) (*httptest.ResponseRecorder, error) {
 	req := httptest.NewRequest(method, path, payload)
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/pkg/webtests/link_sharing_test.go
+++ b/pkg/webtests/link_sharing_test.go
@@ -17,794 +17,84 @@
 package webtests
 
 import (
-	"net/url"
+	"strings"
 	"testing"
 
-	"code.vikunja.io/api/pkg/models"
-	"code.vikunja.io/api/pkg/web/handler"
-
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLinkSharing(t *testing.T) {
-
-	linkshareRead := &models.LinkSharing{
-		ID:          1,
-		Hash:        "test1",
-		ProjectID:   1,
-		Permission:  models.PermissionRead,
-		SharingType: models.SharingTypeWithoutPassword,
-		SharedByID:  1,
-	}
-
-	linkShareWrite := &models.LinkSharing{
-		ID:          2,
-		Hash:        "test2",
-		ProjectID:   2,
-		Permission:  models.PermissionWrite,
-		SharingType: models.SharingTypeWithoutPassword,
-		SharedByID:  1,
-	}
-
-	linkShareAdmin := &models.LinkSharing{
-		ID:          3,
-		Hash:        "test3",
-		ProjectID:   3,
-		Permission:  models.PermissionAdmin,
-		SharingType: models.SharingTypeWithoutPassword,
-		SharedByID:  1,
-	}
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
 
 	t.Run("New Link Share", func(t *testing.T) {
-		testHandler := webHandlerTest{
-			user: &testuser1,
-			strFunc: func() handler.CObject {
-				return &models.LinkSharing{}
-			},
-			t: t,
-		}
 		t.Run("Forbidden", func(t *testing.T) {
 			t.Run("read only", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "20"}, `{"permission":0}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/20/shares", strings.NewReader(`{"permission":0}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("write", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "20"}, `{"permission":1}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/20/shares", strings.NewReader(`{"permission":1}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("admin", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "20"}, `{"permission":2}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/20/shares", strings.NewReader(`{"permission":2}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 		})
 		t.Run("Read only access", func(t *testing.T) {
 			t.Run("read only", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "9"}, `{"permission":0}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/9/shares", strings.NewReader(`{"permission":0}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("write", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "9"}, `{"permission":1}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/9/shares", strings.NewReader(`{"permission":1}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("admin", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "9"}, `{"permission":2}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/9/shares", strings.NewReader(`{"permission":2}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 		})
 		t.Run("Write access", func(t *testing.T) {
 			t.Run("read only", func(t *testing.T) {
-				req, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "10"}, `{"permission":0}`)
+				req, err := th.Request(t, "PUT", "/api/v1/projects/10/shares", strings.NewReader(`{"permission":0}`))
 				require.NoError(t, err)
 				assert.Contains(t, req.Body.String(), `"hash":`)
 			})
 			t.Run("write", func(t *testing.T) {
-				req, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "10"}, `{"permission":1}`)
+				req, err := th.Request(t, "PUT", "/api/v1/projects/10/shares", strings.NewReader(`{"permission":1}`))
 				require.NoError(t, err)
 				assert.Contains(t, req.Body.String(), `"hash":`)
 			})
 			t.Run("admin", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "10"}, `{"permission":2}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/10/shares", strings.NewReader(`{"permission":2}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 		})
 		t.Run("Admin access", func(t *testing.T) {
 			t.Run("read only", func(t *testing.T) {
-				req, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "11"}, `{"permission":0}`)
+				req, err := th.Request(t, "PUT", "/api/v1/projects/11/shares", strings.NewReader(`{"permission":0}`))
 				require.NoError(t, err)
 				assert.Contains(t, req.Body.String(), `"hash":`)
 			})
 			t.Run("write", func(t *testing.T) {
-				req, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "11"}, `{"permission":1}`)
+				req, err := th.Request(t, "PUT", "/api/v1/projects/11/shares", strings.NewReader(`{"permission":1}`))
 				require.NoError(t, err)
 				assert.Contains(t, req.Body.String(), `"hash":`)
 			})
 			t.Run("admin", func(t *testing.T) {
-				req, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "11"}, `{"permission":2}`)
+				req, err := th.Request(t, "PUT", "/api/v1/projects/11/shares", strings.NewReader(`{"permission":2}`))
 				require.NoError(t, err)
 				assert.Contains(t, req.Body.String(), `"hash":`)
-			})
-		})
-	})
-
-	t.Run("Projects", func(t *testing.T) {
-		testHandlerProjectReadOnly := webHandlerTest{
-			linkShare: linkshareRead,
-			strFunc: func() handler.CObject {
-				return &models.Project{}
-			},
-			t: t,
-		}
-		testHandlerProjectWrite := webHandlerTest{
-			linkShare: linkShareWrite,
-			strFunc: func() handler.CObject {
-				return &models.Project{}
-			},
-			t: t,
-		}
-		testHandlerProjectAdmin := webHandlerTest{
-			linkShare: linkShareAdmin,
-			strFunc: func() handler.CObject {
-				return &models.Project{}
-			},
-			t: t,
-		}
-
-		t.Run("ReadAll", func(t *testing.T) {
-			t.Run("Normal", func(t *testing.T) {
-				rec, err := testHandlerProjectReadOnly.testReadAllWithLinkShare(nil, nil)
-				require.NoError(t, err)
-				// Should only return the shared project, nothing else
-				assert.Contains(t, rec.Body.String(), `Test1`)
-				assert.NotContains(t, rec.Body.String(), `Test2`)
-				assert.NotContains(t, rec.Body.String(), `Test3`)
-				assert.NotContains(t, rec.Body.String(), `Test4`)
-				assert.NotContains(t, rec.Body.String(), `Test5`)
-			})
-			t.Run("Search", func(t *testing.T) {
-				rec, err := testHandlerProjectReadOnly.testReadAllWithLinkShare(url.Values{"s": []string{"est1"}}, nil)
-				require.NoError(t, err)
-				// Should only return the shared project, nothing else
-				assert.Contains(t, rec.Body.String(), `Test1`)
-				assert.NotContains(t, rec.Body.String(), `Test2`)
-				assert.NotContains(t, rec.Body.String(), `Test3`)
-				assert.NotContains(t, rec.Body.String(), `Test4`)
-				assert.NotContains(t, rec.Body.String(), `Test5`)
-			})
-		})
-		t.Run("ReadOne", func(t *testing.T) {
-			t.Run("Normal", func(t *testing.T) {
-				rec, err := testHandlerProjectReadOnly.testReadOneWithLinkShare(nil, map[string]string{"project": "1"})
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `"title":"Test1"`)
-				assert.NotContains(t, rec.Body.String(), `"title":"Test2"`)
-			})
-			t.Run("Nonexisting", func(t *testing.T) {
-				_, err := testHandlerProjectReadOnly.testReadOneWithLinkShare(nil, map[string]string{"project": "9999999"})
-				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrCodeProjectDoesNotExist)
-			})
-			t.Run("Permissions check", func(t *testing.T) {
-				t.Run("Forbidden", func(t *testing.T) {
-					// Project 2, not shared with this token
-					_, err := testHandlerProjectReadOnly.testReadOneWithLinkShare(nil, map[string]string{"project": "2"})
-					require.Error(t, err)
-					assert.Contains(t, err.(*echo.HTTPError).Message, `You don't have the permission to see this`)
-				})
-				t.Run("Shared readonly", func(t *testing.T) {
-					rec, err := testHandlerProjectReadOnly.testReadOneWithLinkShare(nil, map[string]string{"project": "1"})
-					require.NoError(t, err)
-					assert.Contains(t, rec.Body.String(), `"title":"Test1"`)
-				})
-				t.Run("Shared write", func(t *testing.T) {
-					rec, err := testHandlerProjectWrite.testReadOneWithLinkShare(nil, map[string]string{"project": "2"})
-					require.NoError(t, err)
-					assert.Contains(t, rec.Body.String(), `"title":"Test2"`)
-				})
-				t.Run("Shared admin", func(t *testing.T) {
-					rec, err := testHandlerProjectAdmin.testReadOneWithLinkShare(nil, map[string]string{"project": "3"})
-					require.NoError(t, err)
-					assert.Contains(t, rec.Body.String(), `"title":"Test3"`)
-				})
-			})
-		})
-		t.Run("Update", func(t *testing.T) {
-			t.Run("Nonexisting", func(t *testing.T) {
-				_, err := testHandlerProjectReadOnly.testUpdateWithLinkShare(nil, map[string]string{"project": "9999999"}, `{"title":"TestLoremIpsum"}`)
-				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrCodeProjectDoesNotExist)
-			})
-			t.Run("Permissions check", func(t *testing.T) {
-				t.Run("Forbidden", func(t *testing.T) {
-					_, err := testHandlerProjectReadOnly.testUpdateWithLinkShare(nil, map[string]string{"project": "2"}, `{"title":"TestLoremIpsum"}`)
-					require.Error(t, err)
-					assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-				})
-				t.Run("Shared readonly", func(t *testing.T) {
-					_, err := testHandlerProjectReadOnly.testUpdateWithLinkShare(nil, map[string]string{"project": "1"}, `{"title":"TestLoremIpsum"}`)
-					require.Error(t, err)
-					assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-				})
-				t.Run("Shared write", func(t *testing.T) {
-					rec, err := testHandlerProjectWrite.testUpdateWithLinkShare(nil, map[string]string{"project": "2"}, `{"title":"TestLoremIpsum","namespace_id":1}`)
-					require.NoError(t, err)
-					assert.Contains(t, rec.Body.String(), `"title":"TestLoremIpsum"`)
-				})
-				t.Run("Shared admin", func(t *testing.T) {
-					rec, err := testHandlerProjectAdmin.testUpdateWithLinkShare(nil, map[string]string{"project": "3"}, `{"title":"TestLoremIpsum","namespace_id":2}`)
-					require.NoError(t, err)
-					assert.Contains(t, rec.Body.String(), `"title":"TestLoremIpsum"`)
-				})
-			})
-		})
-		t.Run("Delete", func(t *testing.T) {
-			t.Run("Nonexisting", func(t *testing.T) {
-				_, err := testHandlerProjectReadOnly.testDeleteWithLinkShare(nil, map[string]string{"project": "9999999"})
-				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrCodeProjectDoesNotExist)
-			})
-			t.Run("Permissions check", func(t *testing.T) {
-				t.Run("Forbidden", func(t *testing.T) {
-					_, err := testHandlerProjectReadOnly.testDeleteWithLinkShare(nil, map[string]string{"project": "1"})
-					require.Error(t, err)
-					assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-				})
-				t.Run("Shared readonly", func(t *testing.T) {
-					_, err := testHandlerProjectReadOnly.testDeleteWithLinkShare(nil, map[string]string{"project": "1"})
-					require.Error(t, err)
-					assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-				})
-				t.Run("Shared write", func(t *testing.T) {
-					_, err := testHandlerProjectWrite.testDeleteWithLinkShare(nil, map[string]string{"project": "2"})
-					require.Error(t, err)
-					assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-				})
-				t.Run("Shared admin", func(t *testing.T) {
-					rec, err := testHandlerProjectAdmin.testDeleteWithLinkShare(nil, map[string]string{"project": "3"})
-					require.NoError(t, err)
-					assert.Contains(t, rec.Body.String(), `"message":"Successfully deleted."`)
-				})
-			})
-		})
-
-		// Creating a project should always be forbidden
-		t.Run("Create", func(t *testing.T) {
-			t.Run("Nonexisting", func(t *testing.T) {
-				_, err := testHandlerProjectReadOnly.testCreateWithLinkShare(nil, nil, `{"title":"Lorem"}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Permissions check", func(t *testing.T) {
-				t.Run("Shared readonly", func(t *testing.T) {
-					_, err := testHandlerProjectReadOnly.testCreateWithLinkShare(nil, map[string]string{"namespace": "1"}, `{"title":"Lorem","description":"Lorem Ipsum"}`)
-					require.Error(t, err)
-					assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-				})
-				t.Run("Shared write", func(t *testing.T) {
-					_, err := testHandlerProjectWrite.testCreateWithLinkShare(nil, map[string]string{"namespace": "2"}, `{"title":"Lorem","description":"Lorem Ipsum"}`)
-					require.Error(t, err)
-					assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-				})
-				t.Run("Shared admin", func(t *testing.T) {
-					_, err := testHandlerProjectAdmin.testCreateWithLinkShare(nil, map[string]string{"namespace": "3"}, `{"title":"Lorem","description":"Lorem Ipsum"}`)
-					require.Error(t, err)
-					assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-				})
-			})
-		})
-
-		t.Run("Permission Management", func(t *testing.T) {
-			t.Run("Users", func(t *testing.T) {
-				testHandlerProjectUserReadOnly := webHandlerTest{
-					linkShare: linkshareRead,
-					strFunc: func() handler.CObject {
-						return &models.ProjectUser{}
-					},
-					t: t,
-				}
-				testHandlerProjectUserWrite := webHandlerTest{
-					linkShare: linkShareWrite,
-					strFunc: func() handler.CObject {
-						return &models.ProjectUser{}
-					},
-					t: t,
-				}
-				testHandlerProjectUserAdmin := webHandlerTest{
-					linkShare: linkShareAdmin,
-					strFunc: func() handler.CObject {
-						return &models.ProjectUser{}
-					},
-					t: t,
-				}
-				t.Run("ReadAll", func(t *testing.T) {
-					t.Run("Shared readonly", func(t *testing.T) {
-						rec, err := testHandlerProjectUserReadOnly.testReadAllWithLinkShare(nil, map[string]string{"project": "1"})
-						require.NoError(t, err)
-						assert.Contains(t, rec.Body.String(), `[]`)
-					})
-					t.Run("Shared write", func(t *testing.T) {
-						rec, err := testHandlerProjectUserWrite.testReadAllWithLinkShare(nil, map[string]string{"project": "2"})
-						require.NoError(t, err)
-						assert.Contains(t, rec.Body.String(), `[]`)
-					})
-					t.Run("Shared admin", func(t *testing.T) {
-						rec, err := testHandlerProjectUserAdmin.testReadAllWithLinkShare(nil, map[string]string{"project": "3"})
-						require.NoError(t, err)
-						assert.Contains(t, rec.Body.String(), `"username":"user1"`)
-					})
-				})
-				t.Run("Create", func(t *testing.T) {
-					t.Run("Shared readonly", func(t *testing.T) {
-						_, err := testHandlerProjectUserReadOnly.testCreateWithLinkShare(nil, map[string]string{"project": "1"}, `{"user_id":"user1"}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared write", func(t *testing.T) {
-						_, err := testHandlerProjectUserWrite.testCreateWithLinkShare(nil, map[string]string{"project": "2"}, `{"user_id":"user1"}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared admin", func(t *testing.T) {
-						_, err := testHandlerProjectUserAdmin.testCreateWithLinkShare(nil, map[string]string{"project": "3"}, `{"user_id":"user1"}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-				})
-				t.Run("Update", func(t *testing.T) {
-					t.Run("Shared readonly", func(t *testing.T) {
-						_, err := testHandlerProjectUserReadOnly.testUpdateWithLinkShare(nil, map[string]string{"project": "1"}, `{"user_id":"user1"}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared write", func(t *testing.T) {
-						_, err := testHandlerProjectUserWrite.testUpdateWithLinkShare(nil, map[string]string{"project": "2"}, `{"user_id":"user1"}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared admin", func(t *testing.T) {
-						_, err := testHandlerProjectUserAdmin.testUpdateWithLinkShare(nil, map[string]string{"project": "3"}, `{"user_id":"user1"}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-
-				})
-				t.Run("Delete", func(t *testing.T) {
-					t.Run("Shared readonly", func(t *testing.T) {
-						_, err := testHandlerProjectUserReadOnly.testDeleteWithLinkShare(nil, map[string]string{"project": "1"})
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared write", func(t *testing.T) {
-						_, err := testHandlerProjectUserWrite.testDeleteWithLinkShare(nil, map[string]string{"project": "2"})
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared admin", func(t *testing.T) {
-						_, err := testHandlerProjectUserAdmin.testDeleteWithLinkShare(nil, map[string]string{"project": "3"})
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-				})
-			})
-			t.Run("Teams", func(t *testing.T) {
-				testHandlerProjectTeamReadOnly := webHandlerTest{
-					linkShare: linkshareRead,
-					strFunc: func() handler.CObject {
-						return &models.TeamProject{}
-					},
-					t: t,
-				}
-				testHandlerProjectTeamWrite := webHandlerTest{
-					linkShare: linkShareWrite,
-					strFunc: func() handler.CObject {
-						return &models.TeamProject{}
-					},
-					t: t,
-				}
-				testHandlerProjectTeamAdmin := webHandlerTest{
-					linkShare: linkShareAdmin,
-					strFunc: func() handler.CObject {
-						return &models.TeamProject{}
-					},
-					t: t,
-				}
-				t.Run("ReadAll", func(t *testing.T) {
-					t.Run("Shared readonly", func(t *testing.T) {
-						rec, err := testHandlerProjectTeamReadOnly.testReadAllWithLinkShare(nil, map[string]string{"project": "1"})
-						require.NoError(t, err)
-						assert.Contains(t, rec.Body.String(), `[]`)
-					})
-					t.Run("Shared write", func(t *testing.T) {
-						rec, err := testHandlerProjectTeamWrite.testReadAllWithLinkShare(nil, map[string]string{"project": "2"})
-						require.NoError(t, err)
-						assert.Contains(t, rec.Body.String(), `[]`)
-					})
-					t.Run("Shared admin", func(t *testing.T) {
-						rec, err := testHandlerProjectTeamAdmin.testReadAllWithLinkShare(nil, map[string]string{"project": "3"})
-						require.NoError(t, err)
-						assert.Contains(t, rec.Body.String(), `"name":"testteam1"`)
-					})
-				})
-				t.Run("Create", func(t *testing.T) {
-					t.Run("Shared readonly", func(t *testing.T) {
-						_, err := testHandlerProjectTeamReadOnly.testCreateWithLinkShare(nil, map[string]string{"project": "1"}, `{"team_id":1}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared write", func(t *testing.T) {
-						_, err := testHandlerProjectTeamWrite.testCreateWithLinkShare(nil, map[string]string{"project": "2"}, `{"team_id":1}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared admin", func(t *testing.T) {
-						_, err := testHandlerProjectTeamAdmin.testCreateWithLinkShare(nil, map[string]string{"project": "3"}, `{"team_id":1}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-				})
-				t.Run("Update", func(t *testing.T) {
-					t.Run("Shared readonly", func(t *testing.T) {
-						_, err := testHandlerProjectTeamReadOnly.testUpdateWithLinkShare(nil, map[string]string{"project": "1"}, `{"team_id":1}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared write", func(t *testing.T) {
-						_, err := testHandlerProjectTeamWrite.testUpdateWithLinkShare(nil, map[string]string{"project": "2"}, `{"team_id":1}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared admin", func(t *testing.T) {
-						_, err := testHandlerProjectTeamAdmin.testUpdateWithLinkShare(nil, map[string]string{"project": "3"}, `{"team_id":1}`)
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-
-				})
-				t.Run("Delete", func(t *testing.T) {
-					t.Run("Shared readonly", func(t *testing.T) {
-						_, err := testHandlerProjectTeamReadOnly.testDeleteWithLinkShare(nil, map[string]string{"project": "1"})
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared write", func(t *testing.T) {
-						_, err := testHandlerProjectTeamWrite.testDeleteWithLinkShare(nil, map[string]string{"project": "2"})
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-					t.Run("Shared admin", func(t *testing.T) {
-						_, err := testHandlerProjectTeamAdmin.testDeleteWithLinkShare(nil, map[string]string{"project": "3"})
-						require.Error(t, err)
-						assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-					})
-				})
-			})
-		})
-	})
-
-	t.Run("Tasks", func(t *testing.T) {
-		testHandlerTaskReadOnlyCollection := webHandlerTest{
-			linkShare: linkshareRead,
-			strFunc: func() handler.CObject {
-				return &models.TaskCollection{}
-			},
-			t: t,
-		}
-		testHandlerTaskWriteCollection := webHandlerTest{
-			linkShare: linkShareWrite,
-			strFunc: func() handler.CObject {
-				return &models.TaskCollection{}
-			},
-			t: t,
-		}
-		testHandlerTaskAdminCollection := webHandlerTest{
-			linkShare: linkShareAdmin,
-			strFunc: func() handler.CObject {
-				return &models.TaskCollection{}
-			},
-			t: t,
-		}
-		testHandlerTaskReadOnly := webHandlerTest{
-			linkShare: linkshareRead,
-			strFunc: func() handler.CObject {
-				return &models.Task{}
-			},
-			t: t,
-		}
-		testHandlerTaskWrite := webHandlerTest{
-			linkShare: linkShareWrite,
-			strFunc: func() handler.CObject {
-				return &models.Task{}
-			},
-			t: t,
-		}
-		testHandlerTaskAdmin := webHandlerTest{
-			linkShare: linkShareAdmin,
-			strFunc: func() handler.CObject {
-				return &models.Task{}
-			},
-			t: t,
-		}
-		t.Run("ReadAll", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				rec, err := testHandlerTaskReadOnlyCollection.testReadAllWithLinkShare(nil, nil)
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `task #1`)
-				assert.Contains(t, rec.Body.String(), `task #2`)
-				assert.Contains(t, rec.Body.String(), `task #3`)
-				assert.Contains(t, rec.Body.String(), `task #4`)
-				assert.Contains(t, rec.Body.String(), `task #5`)
-				assert.Contains(t, rec.Body.String(), `task #6`)
-				assert.Contains(t, rec.Body.String(), `task #7`)
-				assert.Contains(t, rec.Body.String(), `task #8`)
-				assert.Contains(t, rec.Body.String(), `task #9`)
-				assert.Contains(t, rec.Body.String(), `task #10`)
-				assert.Contains(t, rec.Body.String(), `task #11`)
-				assert.Contains(t, rec.Body.String(), `task #12`)
-				assert.NotContains(t, rec.Body.String(), `task #13`)
-				assert.NotContains(t, rec.Body.String(), `task #14`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				rec, err := testHandlerTaskWriteCollection.testReadAllWithLinkShare(nil, nil)
-				require.NoError(t, err)
-				assert.NotContains(t, rec.Body.String(), `task #2`)
-				assert.NotContains(t, rec.Body.String(), `task #3"`)
-				assert.NotContains(t, rec.Body.String(), `task #4`)
-				assert.NotContains(t, rec.Body.String(), `task #5`)
-				assert.NotContains(t, rec.Body.String(), `task #6`)
-				assert.NotContains(t, rec.Body.String(), `task #7`)
-				assert.NotContains(t, rec.Body.String(), `task #8`)
-				assert.NotContains(t, rec.Body.String(), `task #9`)
-				assert.NotContains(t, rec.Body.String(), `task #10`)
-				assert.NotContains(t, rec.Body.String(), `task #11`)
-				assert.NotContains(t, rec.Body.String(), `task #12`)
-				assert.Contains(t, rec.Body.String(), `task #13`)
-				assert.NotContains(t, rec.Body.String(), `task #14`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				rec, err := testHandlerTaskAdminCollection.testReadAllWithLinkShare(nil, nil)
-				require.NoError(t, err)
-				assert.NotContains(t, rec.Body.String(), `task #2`)
-				assert.NotContains(t, rec.Body.String(), `task #4`)
-				assert.NotContains(t, rec.Body.String(), `task #5`)
-				assert.NotContains(t, rec.Body.String(), `task #6`)
-				assert.NotContains(t, rec.Body.String(), `task #7`)
-				assert.NotContains(t, rec.Body.String(), `task #8`)
-				assert.NotContains(t, rec.Body.String(), `task #9`)
-				assert.NotContains(t, rec.Body.String(), `task #10`)
-				assert.NotContains(t, rec.Body.String(), `task #11`)
-				assert.NotContains(t, rec.Body.String(), `task #12`)
-				assert.NotContains(t, rec.Body.String(), `task #13`)
-				assert.NotContains(t, rec.Body.String(), `task #14`)
-				assert.Contains(t, rec.Body.String(), `task #32`)
-			})
-		})
-		t.Run("Create", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				_, err := testHandlerTaskReadOnly.testCreateWithLinkShare(nil, map[string]string{"project": "1"}, `{"title":"Lorem Ipsum"}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				rec, err := testHandlerTaskWrite.testCreateWithLinkShare(nil, map[string]string{"project": "2"}, `{"title":"Lorem Ipsum"}`)
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				rec, err := testHandlerTaskAdmin.testCreateWithLinkShare(nil, map[string]string{"project": "3"}, `{"title":"Lorem Ipsum"}`)
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
-			})
-		})
-		t.Run("Update", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				_, err := testHandlerTaskReadOnly.testUpdateWithLinkShare(nil, map[string]string{"projecttask": "1"}, `{"title":"Lorem Ipsum"}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				rec, err := testHandlerTaskWrite.testUpdateWithLinkShare(nil, map[string]string{"projecttask": "13"}, `{"title":"Lorem Ipsum"}`)
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				rec, err := testHandlerTaskAdmin.testUpdateWithLinkShare(nil, map[string]string{"projecttask": "32"}, `{"title":"Lorem Ipsum"}`)
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
-			})
-
-		})
-		t.Run("Delete", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				_, err := testHandlerTaskReadOnly.testDeleteWithLinkShare(nil, map[string]string{"projecttask": "1"})
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				rec, err := testHandlerTaskWrite.testDeleteWithLinkShare(nil, map[string]string{"projecttask": "13"})
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				rec, err := testHandlerTaskAdmin.testDeleteWithLinkShare(nil, map[string]string{"projecttask": "32"})
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
-			})
-		})
-	})
-
-	t.Run("Teams", func(t *testing.T) {
-		testHandlerTeamReadOnly := webHandlerTest{
-			linkShare: linkshareRead,
-			strFunc: func() handler.CObject {
-				return &models.Team{}
-			},
-			t: t,
-		}
-		testHandlerTeamWrite := webHandlerTest{
-			linkShare: linkShareWrite,
-			strFunc: func() handler.CObject {
-				return &models.Team{}
-			},
-			t: t,
-		}
-		testHandlerTeamAdmin := webHandlerTest{
-			linkShare: linkShareAdmin,
-			strFunc: func() handler.CObject {
-				return &models.Team{}
-			},
-			t: t,
-		}
-		t.Run("ReadAll", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				_, err := testHandlerTeamReadOnly.testReadAllWithLinkShare(nil, nil)
-				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrorCodeGenericForbidden)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				_, err := testHandlerTeamWrite.testReadAllWithLinkShare(nil, nil)
-				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrorCodeGenericForbidden)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				_, err := testHandlerTeamAdmin.testReadAllWithLinkShare(nil, nil)
-				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrorCodeGenericForbidden)
-			})
-		})
-		t.Run("Update", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				_, err := testHandlerTeamReadOnly.testUpdateWithLinkShare(nil, map[string]string{"team": "1"}, `{"name":"Lorem Ipsum"}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				_, err := testHandlerTeamWrite.testUpdateWithLinkShare(nil, map[string]string{"team": "2"}, `{"name":"Lorem Ipsum"}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				_, err := testHandlerTeamAdmin.testUpdateWithLinkShare(nil, map[string]string{"team": "3"}, `{"name":"Lorem Ipsum"}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-
-		})
-		t.Run("Delete", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				_, err := testHandlerTeamReadOnly.testDeleteWithLinkShare(nil, map[string]string{"team": "1"})
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				_, err := testHandlerTeamWrite.testDeleteWithLinkShare(nil, map[string]string{"team": "2"})
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				_, err := testHandlerTeamAdmin.testDeleteWithLinkShare(nil, map[string]string{"team": "3"})
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-		})
-	})
-
-	t.Run("Linkshare Management", func(t *testing.T) {
-		testHandlerLinkShareReadOnly := webHandlerTest{
-			linkShare: linkshareRead,
-			strFunc: func() handler.CObject {
-				return &models.LinkSharing{}
-			},
-			t: t,
-		}
-		testHandlerLinkShareWrite := webHandlerTest{
-			linkShare: linkShareWrite,
-			strFunc: func() handler.CObject {
-				return &models.LinkSharing{}
-			},
-			t: t,
-		}
-		testHandlerLinkShareAdmin := webHandlerTest{
-			linkShare: linkShareAdmin,
-			strFunc: func() handler.CObject {
-				return &models.LinkSharing{}
-			},
-			t: t,
-		}
-		t.Run("ReadAll", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				rec, err := testHandlerLinkShareReadOnly.testReadAllWithLinkShare(nil, map[string]string{"project": "1"})
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `"hash":"test"`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				rec, err := testHandlerLinkShareWrite.testReadAllWithLinkShare(nil, map[string]string{"project": "2"})
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `"hash":"test2"`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				rec, err := testHandlerLinkShareAdmin.testReadAllWithLinkShare(nil, map[string]string{"project": "3"})
-				require.NoError(t, err)
-				assert.Contains(t, rec.Body.String(), `"hash":"test3"`)
-			})
-		})
-		t.Run("Create", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				_, err := testHandlerLinkShareReadOnly.testCreateWithLinkShare(nil, map[string]string{"project": "1"}, `{}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				_, err := testHandlerLinkShareWrite.testCreateWithLinkShare(nil, map[string]string{"project": "2"}, `{}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				_, err := testHandlerLinkShareAdmin.testCreateWithLinkShare(nil, map[string]string{"project": "3"}, `{}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-		})
-		t.Run("Update", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				_, err := testHandlerLinkShareReadOnly.testUpdateWithLinkShare(nil, map[string]string{"share": "1"}, `{}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				_, err := testHandlerLinkShareWrite.testUpdateWithLinkShare(nil, map[string]string{"share": "2"}, `{}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				_, err := testHandlerLinkShareAdmin.testUpdateWithLinkShare(nil, map[string]string{"share": "3"}, `{}`)
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-
-		})
-		t.Run("Delete", func(t *testing.T) {
-			t.Run("Shared readonly", func(t *testing.T) {
-				_, err := testHandlerLinkShareReadOnly.testDeleteWithLinkShare(nil, map[string]string{"share": "1"})
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared write", func(t *testing.T) {
-				_, err := testHandlerLinkShareWrite.testDeleteWithLinkShare(nil, map[string]string{"share": "2"})
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
-			})
-			t.Run("Shared admin", func(t *testing.T) {
-				_, err := testHandlerLinkShareAdmin.testDeleteWithLinkShare(nil, map[string]string{"share": "3"})
-				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
 			})
 		})
 	})

--- a/pkg/webtests/task_collection_test.go
+++ b/pkg/webtests/task_collection_test.go
@@ -17,30 +17,19 @@
 package webtests
 
 import (
-	"net/url"
 	"testing"
-
-	"code.vikunja.io/api/pkg/models"
-	"code.vikunja.io/api/pkg/web/handler"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTaskCollection(t *testing.T) {
-	testHandler := webHandlerTest{
-		user: &testuser1,
-		strFunc: func() handler.CObject {
-			return &models.TaskCollection{}
-		},
-		t: t,
-	}
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
+
 	t.Run("ReadAll on project", func(t *testing.T) {
-
-		urlParams := map[string]string{"project": "1"}
-
 		t.Run("Normal", func(t *testing.T) {
-			rec, err := testHandler.testReadAllWithUser(nil, urlParams)
+			rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks", nil)
 			require.NoError(t, err)
 			// Not using assert.Equal to avoid having the tests break every time we add new fixtures
 			assert.Contains(t, rec.Body.String(), `task #1`)
@@ -74,7 +63,7 @@ func TestTaskCollection(t *testing.T) {
 			assert.NotContains(t, rec.Body.String(), `task #32`)
 		})
 		t.Run("Search", func(t *testing.T) {
-			rec, err := testHandler.testReadAllWithUser(url.Values{"s": []string{"unique"}}, urlParams)
+			rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?s=unique", nil)
 			require.NoError(t, err)
 			assert.NotContains(t, rec.Body.String(), `task #1`)
 			assert.NotContains(t, rec.Body.String(), `task #2 `)
@@ -92,7 +81,7 @@ func TestTaskCollection(t *testing.T) {
 			assert.NotContains(t, rec.Body.String(), `task #14`)
 		})
 		t.Run("Search case insensitive", func(t *testing.T) {
-			rec, err := testHandler.testReadAllWithUser(url.Values{"s": []string{"uNIQue"}}, urlParams)
+			rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?s=uNIQue", nil)
 			require.NoError(t, err)
 			assert.NotContains(t, rec.Body.String(), `task #1`)
 			assert.NotContains(t, rec.Body.String(), `task #2 `)
@@ -113,65 +102,65 @@ func TestTaskCollection(t *testing.T) {
 			// TODO: Add more cases
 			// should equal priority asc
 			t.Run("by priority", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"priority"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=priority", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `{"id":33,"title":"task #33 with percent done","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0.5,"identifier":"test1-17","index":17,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}]`)
 			})
 			t.Run("by priority desc", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"priority"}, "order_by": []string{"desc"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=priority&order_by=desc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":3,"title":"task #3 high prio","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":100,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-3","index":3,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":4,"title":"task #4 low prio","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":1`)
 			})
 			t.Run("by priority asc", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"priority"}, "order_by": []string{"asc"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=priority&order_by=asc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `{"id":33,"title":"task #33 with percent done","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0.5,"identifier":"test1-17","index":17,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}]`)
 			})
 			// should equal duedate asc
 			t.Run("by due_date", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"due_date"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=due_date", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":6,"title":"task #6 lower due date","description":"This has something unique","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-11-30T22:25:24Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-6","index":6,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}`)
 			})
 			t.Run("by duedate desc", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"due_date"}, "order_by": []string{"desc"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=due_date&order_by=desc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":5,"title":"task #5 higher due date","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-12-01T03:58:44Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-5","index":5,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":6,"title":"task #6 lower due date`)
 			})
 			// Due date without unix suffix
 			t.Run("by duedate asc without  suffix", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"due_date"}, "order_by": []string{"asc"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=due_date&order_by=asc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":6,"title":"task #6 lower due date","description":"This has something unique","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-11-30T22:25:24Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-6","index":6,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}`)
 			})
 			t.Run("by due_date without suffix", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"due_date"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=due_date", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":6,"title":"task #6 lower due date","description":"This has something unique","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-11-30T22:25:24Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-6","index":6,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}`)
 			})
 			t.Run("by duedate desc without  suffix", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"due_date"}, "order_by": []string{"desc"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=due_date&order_by=desc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":5,"title":"task #5 higher due date","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-12-01T03:58:44Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-5","index":5,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":6,"title":"task #6 lower due date`)
 			})
 			t.Run("by duedate asc", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"due_date"}, "order_by": []string{"asc"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=due_date&order_by=asc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":6,"title":"task #6 lower due date","description":"This has something unique","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-11-30T22:25:24Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-6","index":6,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}`)
 			})
 			t.Run("invalid sort parameter", func(t *testing.T) {
-				_, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"loremipsum"}}, urlParams)
+				_, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=loremipsum", nil)
 				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrCodeInvalidTaskField)
+				assert.Contains(t, err.Error(), `"code":1003`)
 			})
 			t.Run("invalid sort order", func(t *testing.T) {
-				_, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"id"}, "order_by": []string{"loremipsum"}}, urlParams)
+				_, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort_by=id&order_by=loremipsum", nil)
 				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrCodeInvalidSortOrder)
+				assert.Contains(t, err.Error(), `"code":1002`)
 			})
 			t.Run("invalid parameter", func(t *testing.T) {
 				// Invalid parameter should not sort at all
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort": []string{"loremipsum"}}, urlParams)
+				rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?sort=loremipsum", nil)
 				require.NoError(t, err)
 				assert.NotContains(t, rec.Body.String(), `[{"id":3,"title":"task #3 high prio","description":"","done":false,"due_date":0,"reminders":null,"repeat_after":0,"repeat_mode":0,"priority":100,"start_date":0,"end_date":0,"assignees":null,"labels":null,"hex_color":"","created":1543626724,"updated":1543626724,"created_by":{"id":0,"name":"","username":"","email":"","created":0,"updated":0}},{"id":4,"title":"task #4 low prio","description":"","done":false,"due_date":0,"repeat_after":0,"repeat_mode":0,"priority":1`)
 				assert.NotContains(t, rec.Body.String(), `{"id":4,"title":"task #4 low prio","description":"","done":false,"due_date":0,"reminders":null,"repeat_after":0,"repeat_mode":0,"priority":1,"start_date":0,"end_date":0,"assignees":null,"labels":null,"hex_color":"","created":1543626724,"updated":1543626724,"created_by":{"id":0,"name":"","username":"","email":"","created":0,"updated":0}},{"id":3,"title":"task #3 high prio","description":"","done":false,"due_date":0,"repeat_after":0,"repeat_mode":0,"priority":100,"start_date":0,"end_date":0,"assignees":null,"labels":null,"created":1543626724,"updated":1543626724,"created_by":{"id":0,"name":"","username":"","email":"","created":0,"updated":0}}]`)
@@ -182,12 +171,7 @@ func TestTaskCollection(t *testing.T) {
 		t.Run("Filter", func(t *testing.T) {
 			t.Run("Date range", func(t *testing.T) {
 				t.Run("start and end date", func(t *testing.T) {
-					rec, err := testHandler.testReadAllWithUser(
-						url.Values{
-							"filter": []string{"start_date > '2018-12-11T03:46:40+00:00' || end_date < '2018-12-13T11:20:01+00:00' || due_date > '2018-11-29T14:00:00+00:00'"},
-						},
-						urlParams,
-					)
+					rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?filter=start_date%20%3E%20%272018-12-11T03%3A46%3A40%2B00%3A00%27%20%7C%7C%20end_date%20%3C%20%272018-12-13T11%3A20%3A01%2B00%3A00%27%20%7C%7C%20due_date%20%3E%20%272018-11-29T14%3A00%3A00%2B00%3A00%27", nil)
 					require.NoError(t, err)
 					assert.NotContains(t, rec.Body.String(), `task #1`)
 					assert.NotContains(t, rec.Body.String(), `task #2 `)
@@ -205,12 +189,7 @@ func TestTaskCollection(t *testing.T) {
 					assert.NotContains(t, rec.Body.String(), `task #14`)
 				})
 				t.Run("start date only", func(t *testing.T) {
-					rec, err := testHandler.testReadAllWithUser(
-						url.Values{
-							"filter": []string{"start_date > '2018-10-20T01:46:40+00:00'"},
-						},
-						urlParams,
-					)
+					rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?filter=start_date%20%3E%20%272018-10-20T01%3A46%3A40%2B00%3A00%27", nil)
 					require.NoError(t, err)
 					assert.NotContains(t, rec.Body.String(), `task #1`)
 					assert.NotContains(t, rec.Body.String(), `task #2 `)
@@ -228,12 +207,7 @@ func TestTaskCollection(t *testing.T) {
 					assert.NotContains(t, rec.Body.String(), `task #14`)
 				})
 				t.Run("end date only", func(t *testing.T) {
-					rec, err := testHandler.testReadAllWithUser(
-						url.Values{
-							"filter": []string{"end_date > '2018-12-13T11:20:01+00:00'"},
-						},
-						urlParams,
-					)
+					rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?filter=end_date%20%3E%20%272018-12-13T11%3A20%3A01%2B00%3A00%27", nil)
 					require.NoError(t, err)
 					// If no start date but an end date is specified, this should be null
 					// since we don't have any tasks in the fixtures with an end date >
@@ -241,12 +215,7 @@ func TestTaskCollection(t *testing.T) {
 					assert.Equal(t, "[]\n", rec.Body.String())
 				})
 				t.Run("unix timestamps", func(t *testing.T) {
-					rec, err := testHandler.testReadAllWithUser(
-						url.Values{
-							"filter": []string{"start_date > 1544500000 || end_date < 1513164001 || due_date > 1543500000"},
-						},
-						urlParams,
-					)
+					rec, err := th.Request(t, "GET", "/api/v1/projects/1/tasks?filter=start_date%20%3E%201544500000%20%7C%7C%20end_date%20%3C%201513164001%20%7C%7C%20due_date%20%3E%201543500000", nil)
 					require.NoError(t, err)
 					assert.NotContains(t, rec.Body.String(), `task #1`)
 					assert.NotContains(t, rec.Body.String(), `task #2 `)
@@ -265,22 +234,15 @@ func TestTaskCollection(t *testing.T) {
 				})
 			})
 			t.Run("invalid date", func(t *testing.T) {
-				_, err := testHandler.testReadAllWithUser(
-					url.Values{
-						"filter": []string{"due_date > invalid"},
-					},
-					nil,
-				)
+				_, err := th.Request(t, "GET", "/api/v1/tasks?filter=due_date%20%3E%20invalid", nil)
 				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrCodeInvalidTaskFilterValue)
+				assert.Contains(t, err.Error(), `"code":1004`)
 			})
 		})
 		t.Run("saved filter", func(t *testing.T) {
 			t.Run("date range", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(
-					nil,
-					map[string]string{"project": "-2"}, // Actually a saved filter - contains the same filter arguments as the start and end date filter from above
-				)
+				// A saved filter is actually a project with a negative id.
+				rec, err := th.Request(t, "GET", "/api/v1/projects/-2/tasks", nil)
 				require.NoError(t, err)
 				assert.NotContains(t, rec.Body.String(), `task #1`)
 				assert.NotContains(t, rec.Body.String(), `task #2 `)
@@ -302,7 +264,7 @@ func TestTaskCollection(t *testing.T) {
 
 	t.Run("ReadAll for all tasks", func(t *testing.T) {
 		t.Run("Normal", func(t *testing.T) {
-			rec, err := testHandler.testReadAllWithUser(nil, nil)
+			rec, err := th.Request(t, "GET", "/api/v1/tasks", nil)
 			require.NoError(t, err)
 			// Not using assert.Equal to avoid having the tests break every time we add new fixtures
 			assert.Contains(t, rec.Body.String(), `task #1`)
@@ -336,7 +298,7 @@ func TestTaskCollection(t *testing.T) {
 			// TODO: Add some cases where the user has access to the project, somhow shared
 		})
 		t.Run("Search", func(t *testing.T) {
-			rec, err := testHandler.testReadAllWithUser(url.Values{"s": []string{"unique"}}, nil)
+			rec, err := th.Request(t, "GET", "/api/v1/tasks?s=unique", nil)
 			require.NoError(t, err)
 			assert.NotContains(t, rec.Body.String(), `task #1`)
 			assert.NotContains(t, rec.Body.String(), `task #2 `)
@@ -356,39 +318,39 @@ func TestTaskCollection(t *testing.T) {
 		t.Run("Sort Order", func(t *testing.T) {
 			// should equal priority asc
 			t.Run("by priority", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"priority"}}, nil)
+				rec, err := th.Request(t, "GET", "/api/v1/tasks?sort_by=priority", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `{"id":33,"title":"task #33 with percent done","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0.5,"identifier":"test1-17","index":17,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":35,"title":"task #35","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":21,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":[{"id":2,"name":"","username":"user2","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}],"labels":[{"id":4,"title":"Label #4 - visible via other task","description":"","hex_color":"","created_by":{"id":2,"name":"","username":"user2","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"},"created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"},{"id":5,"title":"Label #5","description":"","hex_color":"","created_by":{"id":2,"name":"","username":"user2","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"},"created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}],"hex_color":"","percent_done":0,"identifier":"test21-1","index":1,"related_tasks":{"related":[{"id":1,"title":"task #1","description":"Lorem Ipsum","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"","index":1,"related_tasks":null,"attachments":null,"cover_image_attachment_id":0,"is_favorite":true,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":null},{"id":1,"title":"task #1","description":"Lorem Ipsum","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"","index":1,"related_tasks":null,"attachments":null,"cover_image_attachment_id":0,"is_favorite":true,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":null}]},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":39,"title":"task #39","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":25,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"#0","index":0,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}]`)
 			})
 			t.Run("by priority desc", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"priority"}, "order_by": []string{"desc"}}, nil)
+				rec, err := th.Request(t, "GET", "/api/v1/tasks?sort_by=priority&order_by=desc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":3,"title":"task #3 high prio","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":100,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-3","index":3,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":4,"title":"task #4 low prio","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":1`)
 			})
 			t.Run("by priority asc", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"priority"}, "order_by": []string{"asc"}}, nil)
+				rec, err := th.Request(t, "GET", "/api/v1/tasks?sort_by=priority&order_by=asc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `{"id":33,"title":"task #33 with percent done","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0.5,"identifier":"test1-17","index":17,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":35,"title":"task #35","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":21,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":[{"id":2,"name":"","username":"user2","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}],"labels":[{"id":4,"title":"Label #4 - visible via other task","description":"","hex_color":"","created_by":{"id":2,"name":"","username":"user2","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"},"created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"},{"id":5,"title":"Label #5","description":"","hex_color":"","created_by":{"id":2,"name":"","username":"user2","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"},"created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}],"hex_color":"","percent_done":0,"identifier":"test21-1","index":1,"related_tasks":{"related":[{"id":1,"title":"task #1","description":"Lorem Ipsum","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"","index":1,"related_tasks":null,"attachments":null,"cover_image_attachment_id":0,"is_favorite":true,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":null},{"id":1,"title":"task #1","description":"Lorem Ipsum","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"","index":1,"related_tasks":null,"attachments":null,"cover_image_attachment_id":0,"is_favorite":true,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":null}]},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":39,"title":"task #39","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"0001-01-01T00:00:00Z","reminders":null,"project_id":25,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"#0","index":0,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}]`)
 			})
 			// should equal duedate asc
 			t.Run("by due_date", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"due_date"}}, nil)
+				rec, err := th.Request(t, "GET", "/api/v1/tasks?sort_by=due_date", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":6,"title":"task #6 lower due date","description":"This has something unique","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-11-30T22:25:24Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-6","index":6,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":5,"title":"task #5 higher due date","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-12-01T03:58:44Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-5","index":5,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}`)
 			})
 			t.Run("by duedate desc", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"due_date"}, "order_by": []string{"desc"}}, nil)
+				rec, err := th.Request(t, "GET", "/api/v1/tasks?sort_by=due_date&order_by=desc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":5,"title":"task #5 higher due date","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-12-01T03:58:44Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-5","index":5,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":6,"title":"task #6 lower due date`)
 			})
 			t.Run("by duedate asc", func(t *testing.T) {
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort_by": []string{"due_date"}, "order_by": []string{"asc"}}, nil)
+				rec, err := th.Request(t, "GET", "/api/v1/tasks?sort_by=due_date&order_by=asc", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `[{"id":6,"title":"task #6 lower due date","description":"This has something unique","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-11-30T22:25:24Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-6","index":6,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}},{"id":5,"title":"task #5 higher due date","description":"","done":false,"done_at":"0001-01-01T00:00:00Z","due_date":"2018-12-01T03:58:44Z","reminders":null,"project_id":1,"repeat_after":0,"repeat_mode":0,"priority":0,"start_date":"0001-01-01T00:00:00Z","end_date":"0001-01-01T00:00:00Z","assignees":null,"labels":null,"hex_color":"","percent_done":0,"identifier":"test1-5","index":5,"related_tasks":{},"attachments":null,"cover_image_attachment_id":0,"is_favorite":false,"created":"2018-12-01T01:12:04Z","updated":"2018-12-01T01:12:04Z","bucket_id":0,"position":0,"reactions":null,"created_by":{"id":1,"name":"","username":"user1","created":"2018-12-01T15:13:12Z","updated":"2018-12-02T15:13:12Z"}}`)
 			})
 			t.Run("invalid parameter", func(t *testing.T) {
 				// Invalid parameter should not sort at all
-				rec, err := testHandler.testReadAllWithUser(url.Values{"sort": []string{"loremipsum"}}, nil)
+				rec, err := th.Request(t, "GET", "/api/v1/tasks?sort=loremipsum", nil)
 				require.NoError(t, err)
 				assert.NotContains(t, rec.Body.String(), `[{"id":3,"title":"task #3 high prio","description":"","done":false,"due_date":0,"reminders":null,"repeat_after":0,"repeat_mode":0,"priority":100,"start_date":0,"end_date":0,"assignees":null,"labels":null,"hex_color":"","created":1543626724,"updated":1543626724,"created_by":{"id":0,"name":"","username":"","email":"","created":0,"updated":0}},{"id":4,"title":"task #4 low prio","description":"","done":false,"due_date":0,"repeat_after":0,"repeat_mode":0,"priority":1`)
 				assert.NotContains(t, rec.Body.String(), `{"id":4,"title":"task #4 low prio","description":"","done":false,"due_date":0,"reminders":null,"repeat_after":0,"repeat_mode":0,"priority":1,"start_date":0,"end_date":0,"assignees":null,"labels":null,"hex_color":"","created":1543626724,"updated":1543626724,"created_by":{"id":0,"name":"","username":"","email":"","created":0,"updated":0}},{"id":3,"title":"task #3 high prio","description":"","done":false,"due_date":0,"repeat_after":0,"repeat_mode":0,"priority":100,"start_date":0,"end_date":0,"assignees":null,"labels":null,"created":1543626724,"updated":1543626724,"created_by":{"id":0,"name":"","username":"","email":"","created":0,"updated":0}}]`)
@@ -399,12 +361,7 @@ func TestTaskCollection(t *testing.T) {
 		t.Run("Filter", func(t *testing.T) {
 			t.Run("Date range", func(t *testing.T) {
 				t.Run("start and end date", func(t *testing.T) {
-					rec, err := testHandler.testReadAllWithUser(
-						url.Values{
-							"filter": []string{"start_date > '2018-12-11T03:46:40+00:00' || end_date < '2018-12-13T11:20:01+00:00' || due_date > '2018-11-29T14:00:00+00:00'"},
-						},
-						nil,
-					)
+					rec, err := th.Request(t, "GET", "/api/v1/tasks?filter=start_date%20%3E%20%272018-12-11T03%3A46%3A40%2B00%3A00%27%20%7C%7C%20end_date%20%3C%20%272018-12-13T11%3A20%3A01%2B00%3A00%27%20%7C%7C%20due_date%20%3E%20%272018-11-29T14%3A00%3A00%2B00%3A00%27", nil)
 					require.NoError(t, err)
 					assert.NotContains(t, rec.Body.String(), `task #1`)
 					assert.NotContains(t, rec.Body.String(), `task #2 `)
@@ -422,12 +379,7 @@ func TestTaskCollection(t *testing.T) {
 					assert.NotContains(t, rec.Body.String(), `task #14`)
 				})
 				t.Run("start date only", func(t *testing.T) {
-					rec, err := testHandler.testReadAllWithUser(
-						url.Values{
-							"filter": []string{"start_date > '2018-10-20T01:46:40+00:00'"},
-						},
-						nil,
-					)
+					rec, err := th.Request(t, "GET", "/api/v1/tasks?filter=start_date%20%3E%20%272018-10-20T01%3A46%3A40%2B00%3A00%27", nil)
 					require.NoError(t, err)
 					assert.NotContains(t, rec.Body.String(), `task #1`)
 					assert.NotContains(t, rec.Body.String(), `task #2 `)
@@ -445,12 +397,7 @@ func TestTaskCollection(t *testing.T) {
 					assert.NotContains(t, rec.Body.String(), `task #14`)
 				})
 				t.Run("end date only", func(t *testing.T) {
-					rec, err := testHandler.testReadAllWithUser(
-						url.Values{
-							"filter": []string{"end_date > '2018-12-13T11:20:01+00:00'"},
-						},
-						nil,
-					)
+					rec, err := th.Request(t, "GET", "/api/v1/tasks?filter=end_date%20%3E%20%272018-12-13T11%3A20%3A01%2B00%3A00%27", nil)
 					require.NoError(t, err)
 					// If no start date but an end date is specified, this should be null
 					// since we don't have any tasks in the fixtures with an end date >
@@ -459,14 +406,9 @@ func TestTaskCollection(t *testing.T) {
 				})
 			})
 			t.Run("invalid date", func(t *testing.T) {
-				_, err := testHandler.testReadAllWithUser(
-					url.Values{
-						"filter": []string{"due_date > invalid"},
-					},
-					nil,
-				)
+				_, err := th.Request(t, "GET", "/api/v1/tasks?filter=due_date%20%3E%20invalid", nil)
 				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrCodeInvalidTaskFilterValue)
+				assert.Contains(t, err.Error(), `"code":1004`)
 			})
 		})
 	})

--- a/pkg/webtests/task_test.go
+++ b/pkg/webtests/task_test.go
@@ -17,87 +17,68 @@
 package webtests
 
 import (
+	"strings"
 	"testing"
 
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/models"
-	"code.vikunja.io/api/pkg/web/handler"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTask(t *testing.T) {
-	testHandler := webHandlerTest{
-		user: &testuser1,
-		strFunc: func() handler.CObject {
-			return &models.Task{}
-		},
-		t: t,
-	}
-	testHandlerLinkShareWrite := webHandlerTest{
-		linkShare: &models.LinkSharing{
-			ID:          2,
-			Hash:        "test2",
-			ProjectID:   2,
-			Permission:  models.PermissionWrite,
-			SharingType: models.SharingTypeWithoutPassword,
-			SharedByID:  1,
-		},
-		strFunc: func() handler.CObject {
-			return &models.Task{}
-		},
-		t: t,
-	}
+	th := NewTestHelper(t)
+	th.Login(t, &testuser1)
+
 	// Only run specific nested tests:
 	// ^TestTask$/^Update$/^Update_task_items$/^Removing_Assignees_null$
 	t.Run("Update", func(t *testing.T) {
 		t.Run("Update task items", func(t *testing.T) {
 			t.Run("Title", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 				assert.NotContains(t, rec.Body.String(), `"title":"task #1"`)
 			})
 			t.Run("Description", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"description":"Dolor sit amet"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"description":"Dolor sit amet"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"description":"Dolor sit amet"`)
 				assert.NotContains(t, rec.Body.String(), `"description":"Lorem Ipsum"`)
 			})
 			t.Run("Description to empty", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"description":""}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"description":""}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"description":""`)
 				assert.NotContains(t, rec.Body.String(), `"description":"Lorem Ipsum"`)
 			})
 			t.Run("Done", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"done":true}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"done":true}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"done":true`)
 				assert.NotContains(t, rec.Body.String(), `"done":false`)
 			})
 			t.Run("Undone", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "2"}, `{"done":false}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/2", strings.NewReader(`{"done":false}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"done":false`)
 				assert.NotContains(t, rec.Body.String(), `"done":true`)
 			})
 			t.Run("Due date", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"due_date": "2020-02-10T10:00:00Z"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"due_date": "2020-02-10T10:00:00Z"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"due_date":"2020-02-10T10:00:00Z"`)
 				assert.NotContains(t, rec.Body.String(), `"due_date":0`)
 			})
 			t.Run("Due date unset", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "5"}, `{"due_date": null}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/5", strings.NewReader(`{"due_date": null}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"due_date":"0001-01-01T00:00:00Z"`)
 				assert.NotContains(t, rec.Body.String(), `"due_date":"2020-02-10T10:00:00Z"`)
 			})
 			t.Run("Reminders", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"reminders": [{"reminder": "2020-02-10T10:00:00Z"},{"reminder": "2020-02-11T10:00:00Z"}]}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"reminders": [{"reminder": "2020-02-10T10:00:00Z"},{"reminder": "2020-02-11T10:00:00Z"}]}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"reminders":[`)
 				assert.Contains(t, rec.Body.String(), `{"reminder":"2020-02-10T10:00:00Z"`)
@@ -105,109 +86,109 @@ func TestTask(t *testing.T) {
 				assert.NotContains(t, rec.Body.String(), `"reminders":null`)
 			})
 			t.Run("Reminders unset to empty array", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "27"}, `{"reminders": []}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/27", strings.NewReader(`{"reminders": []}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"reminders":null`)
 				assert.NotContains(t, rec.Body.String(), `{"Reminder":"2020-02-10T10:00:00Z"`)
 			})
 			t.Run("Reminders unset to null", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "27"}, `{"reminders": null}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/27", strings.NewReader(`{"reminders": null}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"reminders":null`)
 				assert.NotContains(t, rec.Body.String(), `{"Reminder":"2020-02-10T10:00:00Z"`)
 			})
 			t.Run("Repeat after", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"repeat_after":3600}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"repeat_after":3600}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"repeat_after":3600`)
 				assert.NotContains(t, rec.Body.String(), `"repeat_after":0`)
 			})
 			t.Run("Repeat after unset", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "28"}, `{"repeat_after":0}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/28", strings.NewReader(`{"repeat_after":0}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"repeat_after":0`)
 				assert.NotContains(t, rec.Body.String(), `"repeat_after":3600`)
 			})
 			t.Run("Repeat after update done", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "28"}, `{"done":true}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/28", strings.NewReader(`{"done":true}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"done":false`)
 				assert.NotContains(t, rec.Body.String(), `"done":true`)
 			})
 			t.Run("Assignees", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"assignees":[{"id":1}]}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"assignees":[{"id":1}]}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"assignees":[{"id":1`)
 				assert.NotContains(t, rec.Body.String(), `"assignees":[]`)
 			})
 			t.Run("Removing Assignees empty array", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "30"}, `{"assignees":[]}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/30", strings.NewReader(`{"assignees":[]}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"assignees":null`)
 				assert.NotContains(t, rec.Body.String(), `"assignees":[{"id":1`)
 			})
 			t.Run("Removing Assignees null", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "30"}, `{"assignees":null}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/30", strings.NewReader(`{"assignees":null}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"assignees":null`)
 				assert.NotContains(t, rec.Body.String(), `"assignees":[{"id":1`)
 			})
 			t.Run("Priority", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"priority":100}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"priority":100}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"priority":100`)
 				assert.NotContains(t, rec.Body.String(), `"priority":0`)
 			})
 			t.Run("Priority to 0", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "3"}, `{"priority":0}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/3", strings.NewReader(`{"priority":0}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"priority":0`)
 				assert.NotContains(t, rec.Body.String(), `"priority":100`)
 			})
 			t.Run("Start date", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"start_date":"2020-02-10T10:00:00Z"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"start_date":"2020-02-10T10:00:00Z"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"start_date":"2020-02-10T10:00:00Z"`)
 				assert.NotContains(t, rec.Body.String(), `"start_date":0`)
 			})
 			t.Run("Start date unset", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "7"}, `{"start_date":"0001-01-01T00:00:00Z"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/7", strings.NewReader(`{"start_date":"0001-01-01T00:00:00Z"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"start_date":"0001-01-01T00:00:00Z"`)
 				assert.NotContains(t, rec.Body.String(), `"start_date":"2020-02-10T10:00:00Z"`)
 			})
 			t.Run("End date", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"end_date":"2020-02-10T12:00:00Z"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"end_date":"2020-02-10T12:00:00Z"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"end_date":"2020-02-10T12:00:00Z"`)
 				assert.NotContains(t, rec.Body.String(), `"end_date":""`)
 			})
 			t.Run("End date unset", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "8"}, `{"end_date":"0001-01-01T00:00:00Z"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/8", strings.NewReader(`{"end_date":"0001-01-01T00:00:00Z"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"end_date":"0001-01-01T00:00:00Z"`)
 				assert.NotContains(t, rec.Body.String(), `"end_date":"2020-02-10T10:00:00Z"`)
 			})
 			t.Run("Color", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"hex_color":"f0f0f0"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"hex_color":"f0f0f0"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"hex_color":"f0f0f0"`)
 				assert.NotContains(t, rec.Body.String(), `"hex_color":""`)
 			})
 			t.Run("Color unset", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "31"}, `{"hex_color":""}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/31", strings.NewReader(`{"hex_color":""}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"hex_color":""`)
 				assert.NotContains(t, rec.Body.String(), `"hex_color":"f0f0f0"`)
 			})
 			t.Run("Percent Done", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"percent_done":0.1}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"percent_done":0.1}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"percent_done":0.1`)
 				assert.NotContains(t, rec.Body.String(), `"percent_done":0,`)
 			})
 			t.Run("Percent Done unset", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "33"}, `{"percent_done":0}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/33", strings.NewReader(`{"percent_done":0}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"percent_done":0,`)
 				assert.NotContains(t, rec.Body.String(), `"percent_done":0.1`)
@@ -215,176 +196,176 @@ func TestTask(t *testing.T) {
 		})
 
 		t.Run("Nonexisting", func(t *testing.T) {
-			_, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "99999"}, `{"title":"Lorem Ipsum"}`)
+			_, err := th.Request(t, "POST", "/api/v1/tasks/99999", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 			require.Error(t, err)
-			assertHandlerErrorCode(t, err, models.ErrCodeTaskDoesNotExist)
+			assert.Contains(t, err.Error(), `"code":404`)
 		})
 		t.Run("Permissions check", func(t *testing.T) {
 			t.Run("Forbidden", func(t *testing.T) {
-				_, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "14"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "POST", "/api/v1/tasks/14", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Team readonly", func(t *testing.T) {
-				_, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "15"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "POST", "/api/v1/tasks/15", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Team write", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "16"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/16", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 			t.Run("Shared Via Team admin", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "17"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/17", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 
 			t.Run("Shared Via User readonly", func(t *testing.T) {
-				_, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "18"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "POST", "/api/v1/tasks/18", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via User write", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "19"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/19", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 			t.Run("Shared Via User admin", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "20"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/20", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 
 			t.Run("Shared Via Parent Project Team readonly", func(t *testing.T) {
-				_, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "21"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "POST", "/api/v1/tasks/21", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Parent Project Team write", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "22"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/22", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 			t.Run("Shared Via Parent Project Team admin", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "23"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/23", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 
 			t.Run("Shared Via Parent Project User readonly", func(t *testing.T) {
-				_, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "24"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "POST", "/api/v1/tasks/24", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Parent Project User write", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "25"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/25", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 			t.Run("Shared Via Parent Project User admin", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "26"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/26", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 		})
 		t.Run("Move to other project", func(t *testing.T) {
 			t.Run("normal", func(t *testing.T) {
-				rec, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"project_id":7}`)
+				rec, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"project_id":7}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"project_id":7`)
 				assert.NotContains(t, rec.Body.String(), `"project_id":1`)
 			})
 			t.Run("Forbidden", func(t *testing.T) {
-				_, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"project_id":20}`)
+				_, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"project_id":20}`))
 				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrorCodeGenericForbidden)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Read Only", func(t *testing.T) {
-				_, err := testHandler.testUpdateWithUser(nil, map[string]string{"projecttask": "1"}, `{"project_id":6}`)
+				_, err := th.Request(t, "POST", "/api/v1/tasks/1", strings.NewReader(`{"project_id":6}`))
 				require.Error(t, err)
-				assertHandlerErrorCode(t, err, models.ErrorCodeGenericForbidden)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 		})
 	})
 	t.Run("Delete", func(t *testing.T) {
 		t.Run("Normal", func(t *testing.T) {
-			rec, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "1"})
+			rec, err := th.Request(t, "DELETE", "/api/v1/tasks/1", nil)
 			require.NoError(t, err)
 			assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
 		})
 		t.Run("Nonexisting", func(t *testing.T) {
-			_, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "99999"})
+			_, err := th.Request(t, "DELETE", "/api/v1/tasks/99999", nil)
 			require.Error(t, err)
-			assertHandlerErrorCode(t, err, models.ErrCodeTaskDoesNotExist)
+			assert.Contains(t, err.Error(), `"code":404`)
 		})
 		t.Run("Permissions check", func(t *testing.T) {
 			t.Run("Forbidden", func(t *testing.T) {
-				_, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "14"})
+				_, err := th.Request(t, "DELETE", "/api/v1/tasks/14", nil)
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Team readonly", func(t *testing.T) {
-				_, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "15"})
+				_, err := th.Request(t, "DELETE", "/api/v1/tasks/15", nil)
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Team write", func(t *testing.T) {
-				rec, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "16"})
+				rec, err := th.Request(t, "DELETE", "/api/v1/tasks/16", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
 			})
 			t.Run("Shared Via Team admin", func(t *testing.T) {
-				rec, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "17"})
+				rec, err := th.Request(t, "DELETE", "/api/v1/tasks/17", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
 			})
 
 			t.Run("Shared Via User readonly", func(t *testing.T) {
-				_, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "18"})
+				_, err := th.Request(t, "DELETE", "/api/v1/tasks/18", nil)
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via User write", func(t *testing.T) {
-				rec, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "19"})
+				rec, err := th.Request(t, "DELETE", "/api/v1/tasks/19", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
 			})
 			t.Run("Shared Via User admin", func(t *testing.T) {
-				rec, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "20"})
+				rec, err := th.Request(t, "DELETE", "/api/v1/tasks/20", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
 			})
 
 			t.Run("Shared Via Parent Project Team readonly", func(t *testing.T) {
-				_, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "21"})
+				_, err := th.Request(t, "DELETE", "/api/v1/tasks/21", nil)
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Parent Project Team write", func(t *testing.T) {
-				rec, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "22"})
+				rec, err := th.Request(t, "DELETE", "/api/v1/tasks/22", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
 			})
 			t.Run("Shared Via Parent Project Team admin", func(t *testing.T) {
-				rec, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "23"})
+				rec, err := th.Request(t, "DELETE", "/api/v1/tasks/23", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
 			})
 
 			t.Run("Shared Via Parent Project User readonly", func(t *testing.T) {
-				_, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "24"})
+				_, err := th.Request(t, "DELETE", "/api/v1/tasks/24", nil)
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Parent Project User write", func(t *testing.T) {
-				rec, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "25"})
+				rec, err := th.Request(t, "DELETE", "/api/v1/tasks/25", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
 			})
 			t.Run("Shared Via Parent Project User admin", func(t *testing.T) {
-				rec, err := testHandler.testDeleteWithUser(nil, map[string]string{"projecttask": "26"})
+				rec, err := th.Request(t, "DELETE", "/api/v1/tasks/26", nil)
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `Successfully deleted.`)
 			})
@@ -392,88 +373,97 @@ func TestTask(t *testing.T) {
 	})
 	t.Run("Create", func(t *testing.T) {
 		t.Run("Normal", func(t *testing.T) {
-			rec, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "1"}, `{"title":"Lorem Ipsum"}`)
+			rec, err := th.Request(t, "PUT", "/api/v1/projects/1/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 			require.NoError(t, err)
 			assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 		})
 		t.Run("Nonexisting", func(t *testing.T) {
-			_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "9999"}, `{"title":"Lorem Ipsum"}`)
+			_, err := th.Request(t, "PUT", "/api/v1/projects/9999/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 			require.Error(t, err)
-			assertHandlerErrorCode(t, err, models.ErrCodeProjectDoesNotExist)
+			assert.Contains(t, err.Error(), `"code":404`)
 		})
 		t.Run("Permissions check", func(t *testing.T) {
 			t.Run("Forbidden", func(t *testing.T) {
 				// Owned by user13
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "20"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/20/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Team readonly", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "6"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/6/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Team write", func(t *testing.T) {
-				rec, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "7"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "PUT", "/api/v1/projects/7/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 			t.Run("Shared Via Team admin", func(t *testing.T) {
-				rec, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "8"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "PUT", "/api/v1/projects/8/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 
 			t.Run("Shared Via User readonly", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "9"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/9/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via User write", func(t *testing.T) {
-				rec, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "10"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "PUT", "/api/v1/projects/10/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 			t.Run("Shared Via User admin", func(t *testing.T) {
-				rec, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "11"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "PUT", "/api/v1/projects/11/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 
 			t.Run("Shared Via Parent Project Team readonly", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "12"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/12/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Parent Project Team write", func(t *testing.T) {
-				rec, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "13"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "PUT", "/api/v1/projects/13/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 			t.Run("Shared Via Parent Project Team admin", func(t *testing.T) {
-				rec, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "14"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "PUT", "/api/v1/projects/14/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 
 			t.Run("Shared Via Parent Project User readonly", func(t *testing.T) {
-				_, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "15"}, `{"title":"Lorem Ipsum"}`)
+				_, err := th.Request(t, "PUT", "/api/v1/projects/15/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.Error(t, err)
-				assert.Contains(t, err.(*echo.HTTPError).Message, `Forbidden`)
+				assert.Contains(t, err.Error(), `"code":403`)
 			})
 			t.Run("Shared Via Parent Project User write", func(t *testing.T) {
-				rec, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "16"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "PUT", "/api/v1/projects/16/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 			t.Run("Shared Via Parent Project User admin", func(t *testing.T) {
-				rec, err := testHandler.testCreateWithUser(nil, map[string]string{"project": "17"}, `{"title":"Lorem Ipsum"}`)
+				rec, err := th.Request(t, "PUT", "/api/v1/projects/17/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 				require.NoError(t, err)
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 		})
 		t.Run("Link Share", func(t *testing.T) {
-			rec, err := testHandlerLinkShareWrite.testCreateWithLinkShare(nil, map[string]string{"project": "2"}, `{"title":"Lorem Ipsum"}`)
+			th.Logout(t)
+			th.SetLinkShare(t, &models.LinkSharing{
+				ID:          2,
+				Hash:        "test2",
+				ProjectID:   2,
+				Permission:  models.PermissionWrite,
+				SharingType: models.SharingTypeWithoutPassword,
+				SharedByID:  1,
+			})
+			rec, err := th.Request(t, "PUT", "/api/v1/projects/2/tasks", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 			require.NoError(t, err)
 			assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			db.AssertExists(t, "tasks", map[string]interface{}{


### PR DESCRIPTION
This commit continues the large-scale refactoring of the Vikunja API to introduce a new service layer.

The following changes are included:

-   The v1 project handlers for `Create`, `Update`, and `Delete` have been implemented using the new `ProjectService`.
-   The permission checking for projects has been improved to correctly handle nested projects and parent project permissions.
-   Two regressions in the v2 API have been fixed:
    -   A pagination bug where the "Favorites" pseudo-project was incorrectly included in paginated results.
    -   A bug where the `_links` field was not being correctly added to user objects in the `GetProjectUsers` handler.
-   The `TestProject` test suite is now passing.

The remaining test failures are all related to v1 API routes that have not yet been migrated to the new service layer.