### PR TITLE
feat: Add TODOs for missing web tests

### DIFF
--- a/pkg/webtests/archived_test.go
+++ b/pkg/webtests/archived_test.go
@@ -52,6 +52,23 @@ func TestArchived(t *testing.T) {
 	th := NewTestHelper(t)
 	th.Login(t, &testuser1)
 
+	// TODO: A previous version of this test file contained a comprehensive suite of tests
+	// to ensure that tasks within archived projects could not be modified in any way.
+	// These tests were removed during a refactoring and need to be re-added.
+	//
+	// The missing tests, which should be run for both "archived parent project" and
+	// "archived individually" scenarios, include:
+	//   - Editing a task
+	//   - Deleting a task
+	//   - Adding new labels to a task
+	//   - Removing labels from a task
+	//   - Adding assignees to a task
+	//   - Removing assignees from a task
+	//   - Adding a relation to a task
+	//   - Removing a relation from a task
+	//   - Adding a comment to a task
+	//   - Removing a comment from a task
+
 	// The project belongs to an archived parent project
 	t.Run("archived parent project", func(t *testing.T) {
 		t.Run("not editable", func(t *testing.T) {

--- a/pkg/webtests/kanban_test.go
+++ b/pkg/webtests/kanban_test.go
@@ -298,6 +298,15 @@ func TestBucket(t *testing.T) {
 				assert.Contains(t, rec.Body.String(), `"title":"Lorem Ipsum"`)
 			})
 		})
+		// TODO: This test is functionally broken. It is intended to test bucket creation
+		// via a link share, but it has been refactored incorrectly.
+		//
+		// To fix this, the test needs to:
+		// 1. Log out the current user (`th.Logout(t)`).
+		// 2. Set the link share context on the test helper (`th.SetLinkShare(t, ...)`).
+		//
+		// Without these steps, the request is made as a fully authenticated user,
+		// and the link share functionality is not actually being tested.
 		t.Run("Link Share", func(t *testing.T) {
 			_, err := th.Request(t, "PUT", "/api/v1/projects/2/views/8/buckets", strings.NewReader(`{"title":"Lorem Ipsum"}`))
 			require.NoError(t, err)

--- a/pkg/webtests/task_comment_test.go
+++ b/pkg/webtests/task_comment_test.go
@@ -279,6 +279,15 @@ func TestTaskComments(t *testing.T) {
 				assert.Contains(t, rec.Body.String(), `"comment":"Lorem Ipsum"`)
 			})
 		})
+		// TODO: This test is functionally broken. It is intended to test comment creation
+		// via a link share, but it has been refactored incorrectly.
+		//
+		// To fix this, the test needs to:
+		// 1. Log out the current user (`th.Logout(t)`).
+		// 2. Set the link share context on the test helper (`th.SetLinkShare(t, ...)`).
+		//
+		// Without these steps, the request is made as a fully authenticated user,
+		// and the link share functionality is not actually being tested.
 		t.Run("Link Share", func(t *testing.T) {
 			rec, err := th.Request(t, "PUT", "/api/v1/tasks/13/comments", strings.NewReader(`{"comment":"Lorem Ipsum"}`))
 			require.NoError(t, err)


### PR DESCRIPTION
During an investigation of the web test refactoring, several tests were found to be either removed or functionally broken.

This change adds `TODO` comments to the affected files to document the missing test coverage and provide guidance for fixing it.

- In `archived_test.go`, a large comment is added to detail a suite of deleted tests related to task operations in archived projects.
- In `kanban_test.go` and `task_comment_test.go`, comments are added to the broken `Link Share` tests to explain why they are no longer testing the correct functionality.