### PR TITLE
feat(services): Refactor TaskService.Create method

### DIFF
--- a/pkg/services/main_test.go
+++ b/pkg/services/main_test.go
@@ -22,7 +22,9 @@ import (
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/events"
+	"code.vikunja.io/api/pkg/files"
 	"code.vikunja.io/api/pkg/log"
+	"code.vikunja.io/api/pkg/modules/keyvalue"
 )
 
 func TestMain(m *testing.M) {
@@ -36,6 +38,8 @@ func TestMain(m *testing.M) {
 
 	InitTests()
 
+	files.InitFileHandler()
+	keyvalue.InitStorage()
 	events.Fake()
 
 	os.Exit(m.Run())

--- a/pkg/services/project.go
+++ b/pkg/services/project.go
@@ -899,6 +899,24 @@ func (p *Project) checkDeletePermission(s *xorm.Session, project *models.Project
 	return permission.MaxPermission >= int(models.PermissionAdmin), nil
 }
 
+// HasPermission checks if a user has a given permission on a project.
+func (p *Project) HasPermission(s *xorm.Session, projectID int64, u *user.User, requiredPermission models.Permission) (bool, error) {
+	projectPermissions, err := p.checkPermissionsForProjects(s, u, []int64{projectID})
+	if err != nil {
+		return false, err
+	}
+	permission, has := projectPermissions[projectID]
+	if !has {
+		return false, nil
+	}
+
+	if int(requiredPermission) <= permission.MaxPermission {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // checkPermissionsForProjects implements the same permission checking logic as the model layer
 // This is extracted from pkg/models/project_permissions.go to avoid circular dependencies
 func (p *Project) checkPermissionsForProjects(s *xorm.Session, u *user.User, projectIDs []int64) (map[int64]*projectPermission, error) {

--- a/pkg/services/task.go
+++ b/pkg/services/task.go
@@ -1,0 +1,130 @@
+package services
+
+import (
+	"errors"
+	"time"
+
+	"code.vikunja.io/api/pkg/events"
+	"code.vikunja.io/api/pkg/files"
+	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/user"
+	"xorm.io/xorm"
+)
+
+// TaskService is a service for tasks.
+type TaskService struct {
+}
+
+// Create creates a new task.
+func (ts *TaskService) Create(s *xorm.Session, t *models.Task, u *user.User) error {
+	if t.ProjectID == 0 {
+		return errors.New("a task needs to be in a project")
+	}
+
+	projectService := &Project{}
+	can, err := projectService.HasPermission(s, t.ProjectID, u, models.PermissionWrite)
+	if err != nil {
+		return err
+	}
+	if !can {
+		return &models.ErrGenericForbidden{}
+	}
+
+	t.CreatedByID = u.ID
+	t.Created = time.Now()
+
+	// Handle Identifier Index
+	var maxIndex int64
+	_, err = s.SQL("SELECT MAX(`index`) FROM `tasks` WHERE `project_id` = ?", t.ProjectID).Get(&maxIndex)
+	if err != nil {
+		return err
+	}
+	t.Index = maxIndex + 1
+
+	// Perform Database Insert
+	if _, err := s.Insert(t); err != nil {
+		return err
+	}
+
+	// Handle Labels
+	if len(t.Labels) > 0 {
+		for _, label := range t.Labels {
+			labelTask := &models.LabelTask{
+				TaskID:  t.ID,
+				LabelID: label.ID,
+			}
+			if _, err := s.Insert(labelTask); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Handle Assignees
+	if len(t.Assignees) > 0 {
+		for _, assignee := range t.Assignees {
+			// Check if the user has access to the project.
+			canRead, err := projectService.HasPermission(s, t.ProjectID, assignee, models.PermissionRead)
+			if err != nil {
+				return err
+			}
+			if !canRead {
+				return &models.ErrUserDoesNotHaveAccessToProject{ProjectID: t.ProjectID, UserID: assignee.ID}
+			}
+
+			taskAssignee := &models.TaskAssginee{
+				TaskID: t.ID,
+				UserID: assignee.ID,
+			}
+			if _, err := s.Insert(taskAssignee); err != nil {
+				return err
+			}
+
+			// Create subscription
+			sub := &models.Subscription{
+				UserID:     assignee.ID,
+				EntityType: models.SubscriptionEntityTask,
+				EntityID:   t.ID,
+			}
+			if err := sub.Create(s, assignee); err != nil && !models.IsErrSubscriptionAlreadyExists(err) {
+				return err
+			}
+		}
+	}
+
+	// Handle Attachments
+	if len(t.Attachments) > 0 {
+		for _, attachment := range t.Attachments {
+			if attachment.File == nil || attachment.File.File == nil {
+				continue
+			}
+
+			file, err := files.Create(attachment.File.File, attachment.File.Name, attachment.File.Size, u)
+			if err != nil {
+				return err
+			}
+
+			attachment.FileID = file.ID
+			attachment.TaskID = t.ID
+			attachment.CreatedByID = u.ID
+			if _, err := s.Insert(attachment); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Update Project Timestamp
+	if _, err := s.ID(t.ProjectID).Cols("updated").Update(&models.Project{}); err != nil {
+		return err
+	}
+
+	// Dispatch Event
+	err = events.Dispatch(&models.TaskCreatedEvent{
+		Task: t,
+		Doer: u,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/services/task_test.go
+++ b/pkg/services/task_test.go
@@ -1,0 +1,171 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/events"
+	"code.vikunja.io/api/pkg/files"
+	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/user"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskService_Create(t *testing.T) {
+	db.LoadAndAssertFixtures(t)
+
+	ts := &TaskService{}
+	u := &user.User{ID: 1}
+	projectWithIdentifier := &models.Project{ID: 1} // From fixtures
+
+	t.Run("Create a simple task", func(t *testing.T) {
+		s := db.NewSession()
+		defer s.Close()
+
+		var maxIndex int64
+		_, err := s.SQL("SELECT MAX(`index`) FROM `tasks` WHERE `project_id` = ?", projectWithIdentifier.ID).Get(&maxIndex)
+		assert.NoError(t, err)
+
+		task := &models.Task{
+			Title:     "Simple Test Task",
+			ProjectID: projectWithIdentifier.ID,
+		}
+
+		err = ts.Create(s, task, u)
+		assert.NoError(t, err)
+		assert.NotZero(t, task.ID, "Task ID should be set")
+		assert.Equal(t, maxIndex+1, task.Index, "Task Index should be the next available one")
+
+		// Verify in DB
+		var savedTask models.Task
+		has, err := s.ID(task.ID).Get(&savedTask)
+		assert.NoError(t, err)
+		assert.True(t, has, "Task should be saved in the database")
+		assert.Equal(t, task.Title, savedTask.Title)
+		assert.Equal(t, u.ID, savedTask.CreatedByID)
+
+		// Verify event
+		events.AssertDispatched(t, &models.TaskCreatedEvent{})
+	})
+
+	t.Run("Create a task with labels", func(t *testing.T) {
+		s := db.NewSession()
+		defer s.Close()
+
+		task := &models.Task{
+			Title:     "Task with Labels",
+			ProjectID: projectWithIdentifier.ID,
+			Labels: []*models.Label{
+				{ID: 1}, // from fixtures
+				{ID: 2}, // from fixtures
+			},
+		}
+		err := ts.Create(s, task, u)
+		assert.NoError(t, err)
+
+		// Verify label associations
+		var labelTasks []models.LabelTask
+		err = s.Where("task_id = ?", task.ID).Find(&labelTasks)
+		assert.NoError(t, err)
+		assert.Len(t, labelTasks, 2)
+	})
+
+	t.Run("Create a task with assignees", func(t *testing.T) {
+		s := db.NewSession()
+		defer s.Close()
+
+		assignee := &user.User{ID: 2} // from fixtures
+		_, err := s.Insert(&models.ProjectUser{UserID: assignee.ID, ProjectID: projectWithIdentifier.ID, Permission: models.PermissionWrite})
+		assert.NoError(t, err)
+
+		task := &models.Task{
+			Title:     "Task with Assignees",
+			ProjectID: projectWithIdentifier.ID,
+			Assignees: []*user.User{assignee},
+		}
+
+		err = ts.Create(s, task, u)
+		assert.NoError(t, err)
+
+		// Verify assignee association
+		var taskAssignee models.TaskAssginee
+		has, err := s.Where("task_id = ? AND user_id = ?", task.ID, assignee.ID).Get(&taskAssignee)
+		assert.NoError(t, err)
+		assert.True(t, has)
+
+		// Verify subscription
+		var subscription models.Subscription
+		has, err = s.Where("entity_type = ? AND entity_id = ? AND user_id = ?", models.SubscriptionEntityTask, task.ID, assignee.ID).Get(&subscription)
+		assert.NoError(t, err)
+		assert.True(t, has)
+	})
+
+	t.Run("Create a task with an attachment", func(t *testing.T) {
+		s := db.NewSession()
+		defer s.Close()
+
+		fs := afero.NewMemMapFs()
+		aferoFile, _ := fs.Create("test.txt")
+		fileContent := "hello world"
+		_, _ = aferoFile.WriteString(fileContent)
+		_ = aferoFile.Sync()
+		_, _ = aferoFile.Seek(0, 0)
+
+		task := &models.Task{
+			Title:     "Task with Attachment",
+			ProjectID: projectWithIdentifier.ID,
+			Attachments: []*models.TaskAttachment{
+				{
+					File: &files.File{
+						File: aferoFile,
+						Name: "test.txt",
+						Size: uint64(len(fileContent)),
+					},
+				},
+			},
+		}
+
+		err := ts.Create(s, task, u)
+		assert.NoError(t, err)
+
+		// Verify attachment
+		var attachment models.TaskAttachment
+		has, err := s.Where("task_id = ?", task.ID).Get(&attachment)
+		assert.NoError(t, err)
+		assert.True(t, has)
+		assert.NotZero(t, attachment.FileID)
+
+		// Verify file
+		var file files.File
+		has, err = s.ID(attachment.FileID).Get(&file)
+		assert.NoError(t, err)
+		assert.True(t, has)
+		assert.Equal(t, "test.txt", file.Name)
+	})
+
+	t.Run("Creating a task should update project timestamp", func(t *testing.T) {
+		s := db.NewSession()
+		defer s.Close()
+
+		var projectBefore models.Project
+		_, err := s.ID(projectWithIdentifier.ID).Get(&projectBefore)
+		assert.NoError(t, err)
+
+		time.Sleep(1 * time.Second) // Ensure timestamp is different
+
+		task := &models.Task{
+			Title:     "Timestamp Test Task",
+			ProjectID: projectWithIdentifier.ID,
+		}
+		err = ts.Create(s, task, u)
+		assert.NoError(t, err)
+
+		var projectAfter models.Project
+		_, err = s.ID(projectWithIdentifier.ID).Get(&projectAfter)
+		assert.NoError(t, err)
+
+		assert.True(t, projectAfter.Updated.After(projectBefore.Updated), "Project Updated timestamp should be newer")
+	})
+}


### PR DESCRIPTION
Refactor the TaskService.Create method to move business logic from the models package to the service layer.

This change follows the "recipe" provided to implement the Create method in the TaskService. It includes:
- Moving permission checking logic to the service layer, introducing a reusable HasPermission method in the ProjectService.
- Handling task identifier index generation.
- Handling the creation of sub-entities: labels, assignees (with subscriptions), and attachments.
- Updating the parent project's timestamp.
- Dispatching a TaskCreatedEvent.

Comprehensive unit tests have been added for the new TaskService.Create method to ensure all business logic is correctly implemented and tested. All unit and web tests pass.