### PR TITLE
fix: pq: invalid input syntax for type json

### DIFF
--- a/pkg/modules/dump/restore.go
+++ b/pkg/modules/dump/restore.go
@@ -238,15 +238,16 @@ func convertFieldValue(fieldName string, value interface{}, isFloat bool) (inter
 			// If it's a CorruptInputError, treat the string as raw data
 			decoded = []byte(v)
 		}
-		
-		// Parse the JSON string into an interface{} so XORM can properly handle it
-		// This is necessary for PostgreSQL which expects actual JSON types, not strings
+
+		// Validate that it's valid JSON and return as json.RawMessage
+		// This is necessary for PostgreSQL which expects JSON types to be valid JSON
 		var jsonValue interface{}
 		if err := json.Unmarshal(decoded, &jsonValue); err != nil {
 			// If parsing fails, return the string as-is (might be a plain string field)
 			return string(decoded), nil
 		}
-		return jsonValue, nil
+		// Return as json.RawMessage so XORM can handle it properly for JSON columns
+		return json.RawMessage(decoded), nil
 	default:
 		return nil, fmt.Errorf("expected string for JSON field '%s', got %T", fieldName, v)
 	}

--- a/pkg/modules/dump/restore_test.go
+++ b/pkg/modules/dump/restore_test.go
@@ -18,6 +18,7 @@ package dump
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,20 +71,20 @@ func TestConvertFieldValue(t *testing.T) {
 			encoded := base64.StdEncoding.EncodeToString([]byte(jsonData))
 			result, err := convertFieldValue("permissions", encoded, false)
 			require.NoError(t, err)
-			// Result should be a map, not a string
-			resultMap, ok := result.(map[string]interface{})
-			require.True(t, ok, "result should be a map")
-			assert.Equal(t, "value", resultMap["key"])
+			// Result should be json.RawMessage
+			rawMsg, ok := result.(json.RawMessage)
+			require.True(t, ok, "result should be json.RawMessage")
+			assert.JSONEq(t, jsonData, string(rawMsg))
 		})
 
 		t.Run("should handle non-base64 string and parse JSON", func(t *testing.T) {
 			jsonData := `{"key": "value"}`
 			result, err := convertFieldValue("permissions", jsonData, false)
 			require.NoError(t, err)
-			// Result should be a map, not a string
-			resultMap, ok := result.(map[string]interface{})
-			require.True(t, ok, "result should be a map")
-			assert.Equal(t, "value", resultMap["key"])
+			// Result should be json.RawMessage
+			rawMsg, ok := result.(json.RawMessage)
+			require.True(t, ok, "result should be json.RawMessage")
+			assert.JSONEq(t, jsonData, string(rawMsg))
 		})
 
 		t.Run("should return nil for 'null' string", func(t *testing.T) {


### PR DESCRIPTION
sql: converting argument $5 type: unsupported type map[string]interface {}, a map